### PR TITLE
feat: add dribbble-inspired layout and theme

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import CameraScreen from './components/CameraScreen';
 import ProgressScreen from './components/ProgressScreen';
 import ProfileScreen from './components/ProfileScreen';
 import { styles } from './constants/styles';
+import { theme } from './constants/theme';
 
 const Tab = createBottomTabNavigator();
 
@@ -54,11 +55,11 @@ export default function App() {
     <NavigationContainer>
       <Tab.Navigator
         screenOptions={{
-          tabBarActiveTintColor: '#4285f4',
+          tabBarActiveTintColor: theme.colors.primary,
           tabBarInactiveTintColor: '#8E8E93',
           headerShown: false,
           tabBarStyle: {
-            backgroundColor: 'white',
+            backgroundColor: theme.colors.background,
             borderTopColor: 'transparent',
             elevation: 10,
             shadowColor: '#000',

--- a/components/CameraScreen.js
+++ b/components/CameraScreen.js
@@ -6,6 +6,8 @@ import { Camera } from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import { styles } from '../constants/styles';
+import Layout from './Layout';
+import { theme } from '../constants/theme';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 export default function CameraScreen({ photos, setPhotos, loading, setLoading }) {
@@ -202,7 +204,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
   }
 
   return (
-    <View style={styles.container}>
+    <Layout>
       <StatusBar barStyle="light-content" />
       <View style={styles.modernHeader}>
         <Text style={styles.modernHeaderTitle}>Capture Progress</Text>
@@ -213,7 +215,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
       {loading ? (
         <View style={styles.loadingContainer}>
           <View style={styles.loadingCard}>
-            <ActivityIndicator size="large" color="#4285f4" />
+            <ActivityIndicator size="large" color={theme.colors.primary} />
             <Text style={styles.loadingTitle}>Analyzing Your Progress</Text>
             <Text style={styles.loadingSubtext}>AI is comparing your photos...</Text>
             <View style={styles.loadingDots}>
@@ -249,7 +251,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
           )}
         </View>
       )}
-    </View>
+    </Layout>
   );
 }
 

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { styles } from '../constants/styles';
+import { theme } from '../constants/theme';
+
+export default function Layout({ children }) {
+  return (
+    <LinearGradient
+      colors={[theme.colors.primary, theme.colors.secondary]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.appBackground}
+    >
+      <SafeAreaView style={styles.appContainer}>{children}</SafeAreaView>
+    </LinearGradient>
+  );
+}

--- a/components/ProfileScreen.js
+++ b/components/ProfileScreen.js
@@ -4,6 +4,8 @@ import { View, Text, ScrollView, TouchableOpacity, TextInput, StatusBar, Alert }
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import { styles } from '../constants/styles';
+import Layout from './Layout';
+import { theme } from '../constants/theme';
 
 export default function ProfileScreen({ photos }) {
   const [goal, setGoal] = useState('');
@@ -42,9 +44,9 @@ export default function ProfileScreen({ photos }) {
   };
 
   return (
-    <View style={styles.container}>
+    <Layout>
       <StatusBar barStyle="light-content" />
-      <LinearGradient colors={['#4285f4', '#1e3c72']} style={styles.gradientHeader}>
+      <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.gradientHeader}>
         <Text style={styles.headerTitle}>Your Profile</Text>
         <Text style={styles.headerSubtitle}>Track your transformation</Text>
       </LinearGradient>
@@ -54,7 +56,7 @@ export default function ProfileScreen({ photos }) {
           <Text style={styles.sectionTitle}>Journey Statistics</Text>
           <View style={styles.statsGrid}>
             <View style={styles.statItem}>
-              <LinearGradient colors={['#4285f4', '#1e3c72']} style={styles.statCircle}>
+              <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.statCircle}>
                 <Text style={styles.statNumber}>{photos.length}</Text>
               </LinearGradient>
               <Text style={styles.statLabel}>Progress Photos</Text>
@@ -81,7 +83,7 @@ export default function ProfileScreen({ photos }) {
             />
           </View>
           <TouchableOpacity style={styles.saveGoalButton} onPress={() => saveGoal(goal)} activeOpacity={0.8}>
-            <LinearGradient colors={['#11998e', '#38ef7d']} style={styles.saveGoalGradient}>
+            <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.saveGoalGradient}>
               <Text style={styles.saveGoalButtonText}>💾 Save Goal</Text>
             </LinearGradient>
           </TouchableOpacity>
@@ -106,7 +108,7 @@ export default function ProfileScreen({ photos }) {
           </View>
         </View>
       </ScrollView>
-    </View>
+    </Layout>
   );
 }
 

--- a/components/ProgressScreen.js
+++ b/components/ProgressScreen.js
@@ -5,6 +5,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
 import { LinearGradient } from 'expo-linear-gradient';
 import { styles } from '../constants/styles';
+import Layout from './Layout';
+import { theme } from '../constants/theme';
 
 export default function ProgressScreen({ photos, setPhotos }) {
   const [compareMode, setCompareMode] = useState(false);
@@ -73,9 +75,9 @@ export default function ProgressScreen({ photos, setPhotos }) {
   };
 
   return (
-    <View style={styles.container}>
+    <Layout>
       <StatusBar barStyle="light-content" />
-      <LinearGradient colors={['#4285f4', '#1e3c72']} style={styles.gradientHeader}>
+      <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.gradientHeader}>
         <Text style={styles.headerTitle}>Your Journey</Text>
         <Text style={styles.headerSubtitle}>
           {photos.length} {photos.length === 1 ? 'milestone' : 'milestones'} captured
@@ -181,7 +183,7 @@ export default function ProgressScreen({ photos, setPhotos }) {
           </>
         )}
       </ScrollView>
-    </View>
+    </Layout>
   );
 }
 

--- a/constants/styles.js
+++ b/constants/styles.js
@@ -1,10 +1,20 @@
 import { StyleSheet } from 'react-native';
+import { theme } from './theme';
 
 export const styles = StyleSheet.create({
+  // App wide layout
+  appBackground: {
+    flex: 1,
+  },
+  appContainer: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+
   // Base Layouts
   container: {
     flex: 1,
-    backgroundColor: '#f8f9fa',
+    backgroundColor: theme.colors.background,
   },
 
   // Welcome Screen Styles

--- a/constants/theme.js
+++ b/constants/theme.js
@@ -1,0 +1,8 @@
+export const theme = {
+  colors: {
+    primary: '#FF6B6B',
+    secondary: '#4ECDC4',
+    background: '#F7F9FC',
+    text: '#1F2937',
+  },
+};


### PR DESCRIPTION
## Summary
- introduce centralized theme and layout wrapper for dribbble-like design
- apply gradient layout across Camera, Progress, and Profile screens
- use theme colors for navigation tabs

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d4478e08323b4577c6f0b7226f6