### PR TITLE
feat: design dribbble-style home screen and tabs

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import * as FileSystem from 'expo-file-system';
+import { Feather } from '@expo/vector-icons';
 
 import CameraScreen from './components/CameraScreen';
 import ProgressScreen from './components/ProgressScreen';
@@ -79,9 +80,9 @@ export default function App() {
         <Tab.Screen
           name="Camera"
           options={{
-            tabBarIcon: ({ color, focused }) => (
+            tabBarIcon: ({ color, size, focused }) => (
               <View style={[styles.tabIcon, focused && styles.tabIconFocused]}>
-                <Text style={{ fontSize: 24, color }}>📸</Text>
+                <Feather name="camera" size={size} color={color} />
               </View>
             ),
           }}
@@ -98,9 +99,9 @@ export default function App() {
         <Tab.Screen
           name="Progress"
           options={{
-            tabBarIcon: ({ color, focused }) => (
+            tabBarIcon: ({ color, size, focused }) => (
               <View style={[styles.tabIcon, focused && styles.tabIconFocused]}>
-                <Text style={{ fontSize: 24, color }}>📊</Text>
+                <Feather name="bar-chart-2" size={size} color={color} />
               </View>
             ),
           }}
@@ -110,9 +111,9 @@ export default function App() {
         <Tab.Screen
           name="Profile"
           options={{
-            tabBarIcon: ({ color, focused }) => (
+            tabBarIcon: ({ color, size, focused }) => (
               <View style={[styles.tabIcon, focused && styles.tabIconFocused]}>
-                <Text style={{ fontSize: 24, color }}>👤</Text>
+                <Feather name="user" size={size} color={color} />
               </View>
             ),
           }}

--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import CameraScreen from './components/CameraScreen';
 import ProgressScreen from './components/ProgressScreen';
 import ProfileScreen from './components/ProfileScreen';
 import { styles } from './constants/styles';
+import { theme } from './constants/theme';
 
 const Tab = createBottomTabNavigator();
 
@@ -54,11 +55,11 @@ export default function App() {
     <NavigationContainer>
       <Tab.Navigator
         screenOptions={{
-          tabBarActiveTintColor: '#4285f4',
+          tabBarActiveTintColor: theme.colors.primary,
           tabBarInactiveTintColor: '#8E8E93',
           headerShown: false,
           tabBarStyle: {
-            backgroundColor: 'white',
+            backgroundColor: theme.colors.background,
             borderTopColor: 'transparent',
             elevation: 10,
             shadowColor: '#000',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to your Expo app 👋
+# Welcome to your Expo app
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useState, useEffect } from 'react';
-import { Text } from 'react-native';
 import { Tabs } from 'expo-router';
-// eslint-disable-next-line import/no-unresolved
+import { Feather } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
+import { theme } from '@/constants/theme';
 
 export const PhotoContext = createContext({
   photos: [],
@@ -48,33 +48,47 @@ export default function TabLayout() {
 
   return (
     <PhotoContext.Provider value={{ photos, setPhotos, loading, setLoading }}>
-      <Tabs initialRouteName="homepage" screenOptions={{ headerShown: false }}>
+      <Tabs
+        initialRouteName="homepage"
+        screenOptions={{
+          headerShown: false,
+          tabBarShowLabel: false,
+          tabBarActiveTintColor: theme.colors.primary,
+          tabBarInactiveTintColor: '#9AA1B9',
+          tabBarStyle: {
+            backgroundColor: '#fff',
+            borderTopWidth: 0,
+            elevation: 5,
+            height: 60,
+          },
+        }}
+      >
         <Tabs.Screen
           name="homepage"
           options={{
             title: 'Home',
-            tabBarIcon: ({ color }) => <Text style={{ fontSize: 24, color }}>🏠</Text>,
+            tabBarIcon: ({ color, size }) => <Feather name="home" size={size} color={color} />,
           }}
         />
         <Tabs.Screen
           name="camera"
           options={{
             title: 'Camera',
-            tabBarIcon: ({ color }) => <Text style={{ fontSize: 24, color }}>📸</Text>,
+            tabBarIcon: ({ color, size }) => <Feather name="camera" size={size} color={color} />,
           }}
         />
         <Tabs.Screen
           name="progress"
           options={{
             title: 'Progress',
-            tabBarIcon: ({ color }) => <Text style={{ fontSize: 24, color }}>📊</Text>,
+            tabBarIcon: ({ color, size }) => <Feather name="bar-chart-2" size={size} color={color} />,
           }}
         />
         <Tabs.Screen
           name="profile"
           options={{
             title: 'Profile',
-            tabBarIcon: ({ color }) => <Text style={{ fontSize: 24, color }}>👤</Text>,
+            tabBarIcon: ({ color, size }) => <Feather name="user" size={size} color={color} />,
           }}
         />
       </Tabs>

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,11 +1,32 @@
 import React from 'react';
-import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import { View, Text, Image, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
 // eslint-disable-next-line import/no-unresolved
 import Svg, { Circle } from 'react-native-svg';
+import { Feather } from '@expo/vector-icons';
 
 import Layout from '@/components/Layout';
 import { theme } from '@/constants/theme';
+
+const workouts = [
+  {
+    id: 1,
+    title: 'Full Body',
+    time: '8:00 AM',
+    image: require('../../assets/images/react-logo.png'),
+  },
+  {
+    id: 2,
+    title: 'Yoga Stretch',
+    time: '9:00 AM',
+    image: require('../../assets/images/react-logo.png'),
+  },
+  {
+    id: 3,
+    title: 'HIIT Blast',
+    time: '10:00 AM',
+    image: require('../../assets/images/react-logo.png'),
+  },
+];
 
 export default function Homepage() {
   const progress = 0.7;
@@ -17,74 +38,88 @@ export default function Homepage() {
 
   return (
     <Layout>
-      <View style={styles.header}>
-        <View>
-          <Text style={styles.greeting}>Hello, John</Text>
-          <Text style={styles.subtitle}>Ready for your workout?</Text>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <View>
+            <Text style={styles.greeting}>Hello, John</Text>
+            <Text style={styles.subtitle}>Ready for your workout?</Text>
+          </View>
+          <Image source={require('../../assets/images/icon.png')} style={styles.avatar} />
         </View>
-        <Image source={require('../../assets/images/icon.png')} style={styles.avatar} />
-      </View>
 
-      <LinearGradient
-        colors={[theme.colors.primary, theme.colors.secondary]}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={styles.workoutCard}
-      >
-        <View style={styles.workoutText}>
-          <Text style={styles.workoutTitle}>Daily Workout</Text>
-          <Text style={styles.workoutTime}>8:00 AM</Text>
-          <TouchableOpacity style={styles.workoutButton}>
-            <Text style={styles.workoutButtonText}>Start</Text>
-          </TouchableOpacity>
-        </View>
-        <Image source={require('../../assets/images/react-logo.png')} style={styles.workoutImage} />
-      </LinearGradient>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.workoutScroll}
+        >
+          {workouts.map((item) => (
+            <View key={item.id} style={styles.workoutCard}>
+              <View style={styles.workoutInfo}>
+                <Text style={styles.workoutTitle}>{item.title}</Text>
+                <Text style={styles.workoutTime}>{item.time}</Text>
+                <TouchableOpacity style={styles.playButton}>
+                  <Feather name="play" size={16} color="#fff" />
+                </TouchableOpacity>
+              </View>
+              <Image source={item.image} style={styles.workoutImage} />
+            </View>
+          ))}
+        </ScrollView>
 
-      <View style={styles.progressSection}>
-        <Svg width={size} height={size}>
-          <Circle
-            stroke="#e6e6e6"
-            cx={size / 2}
-            cy={size / 2}
-            r={radius}
-            strokeWidth={strokeWidth}
-            fill="none"
-          />
-          <Circle
-            stroke={theme.colors.primary}
-            cx={size / 2}
-            cy={size / 2}
-            r={radius}
-            strokeWidth={strokeWidth}
-            fill="none"
-            strokeDasharray={`${circumference} ${circumference}`}
-            strokeDashoffset={strokeDashoffset}
-            strokeLinecap="round"
-            rotation="-90"
-            origin={`${size / 2},${size / 2}`}
-          />
-        </Svg>
-        <View style={styles.progressLabel}>
-          <Text style={styles.progressPercent}>70%</Text>
-          <Text style={styles.progressText}>Completed</Text>
+        <View style={styles.progressSection}>
+          <Svg width={size} height={size}>
+            <Circle
+              stroke="#e6e6e6"
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              strokeWidth={strokeWidth}
+              fill="none"
+            />
+            <Circle
+              stroke={theme.colors.primary}
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              strokeWidth={strokeWidth}
+              fill="none"
+              strokeDasharray={`${circumference} ${circumference}`}
+              strokeDashoffset={strokeDashoffset}
+              strokeLinecap="round"
+              rotation="-90"
+              origin={`${size / 2},${size / 2}`}
+            />
+          </Svg>
+          <View style={styles.progressLabel}>
+            <Text style={styles.progressPercent}>70%</Text>
+            <Text style={styles.progressText}>Completed</Text>
+          </View>
         </View>
-      </View>
 
-      <View style={styles.statsRow}>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>350</Text>
-          <Text style={styles.statLabel}>Cal</Text>
+        <View style={styles.statsGrid}>
+          <View style={styles.statCard}>
+            <Feather name="fire" size={24} color={theme.colors.primary} />
+            <View style={styles.statInfo}>
+              <Text style={styles.statValue}>350</Text>
+              <Text style={styles.statLabel}>Calories</Text>
+            </View>
+          </View>
+          <View style={styles.statCard}>
+            <Feather name="clock" size={24} color={theme.colors.primary} />
+            <View style={styles.statInfo}>
+              <Text style={styles.statValue}>45m</Text>
+              <Text style={styles.statLabel}>Time</Text>
+            </View>
+          </View>
+          <View style={styles.statCard}>
+            <Feather name="heart" size={24} color={theme.colors.primary} />
+            <View style={styles.statInfo}>
+              <Text style={styles.statValue}>120</Text>
+              <Text style={styles.statLabel}>BPM</Text>
+            </View>
+          </View>
         </View>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>45m</Text>
-          <Text style={styles.statLabel}>Time</Text>
-        </View>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>120</Text>
-          <Text style={styles.statLabel}>BPM</Text>
-        </View>
-      </View>
+      </ScrollView>
     </Layout>
   );
 }
@@ -111,40 +146,47 @@ const styles = StyleSheet.create({
     height: 48,
     borderRadius: 24,
   },
+  workoutScroll: {
+    paddingBottom: 16,
+  },
   workoutCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    marginRight: 16,
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: 20,
-    padding: 20,
-    marginBottom: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 4,
   },
-  workoutText: {
+  workoutInfo: {
     flex: 1,
   },
   workoutTitle: {
-    color: '#fff',
     fontSize: 18,
     fontWeight: '600',
+    color: theme.colors.text,
     marginBottom: 4,
   },
   workoutTime: {
-    color: '#fff',
+    color: '#6B7280',
     marginBottom: 12,
   },
-  workoutButton: {
-    backgroundColor: '#fff',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 20,
-    alignSelf: 'flex-start',
-  },
-  workoutButtonText: {
-    color: theme.colors.primary,
-    fontWeight: '600',
+  playButton: {
+    backgroundColor: theme.colors.primary,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   workoutImage: {
     width: 80,
     height: 80,
+    marginLeft: 10,
   },
   progressSection: {
     alignItems: 'center',
@@ -165,22 +207,27 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
     opacity: 0.7,
   },
-  statsRow: {
+  statsGrid: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     justifyContent: 'space-between',
   },
   statCard: {
-    flex: 1,
-    backgroundColor: '#fff',
-    marginHorizontal: 4,
-    borderRadius: 16,
-    paddingVertical: 16,
+    width: '48%',
+    flexDirection: 'row',
     alignItems: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
     shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.05,
     shadowRadius: 6,
-    shadowOffset: { width: 0, height: 2 },
     elevation: 3,
+  },
+  statInfo: {
+    marginLeft: 12,
   },
   statValue: {
     fontSize: 18,

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,21 +1,196 @@
-import { StyleSheet } from 'react-native';
+import React from 'react';
+import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+// eslint-disable-next-line import/no-unresolved
+import Svg, { Circle } from 'react-native-svg';
 
-import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
+import Layout from '@/components/Layout';
+import { theme } from '@/constants/theme';
 
 export default function Homepage() {
+  const progress = 0.7;
+  const size = 120;
+  const strokeWidth = 12;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference * (1 - progress);
+
   return (
-    <ThemedView style={styles.container}>
-      <ThemedText type="title">Fitness Journey Progress</ThemedText>
-    </ThemedView>
+    <Layout>
+      <View style={styles.header}>
+        <View>
+          <Text style={styles.greeting}>Hello, John</Text>
+          <Text style={styles.subtitle}>Ready for your workout?</Text>
+        </View>
+        <Image source={require('../../assets/images/icon.png')} style={styles.avatar} />
+      </View>
+
+      <LinearGradient
+        colors={[theme.colors.primary, theme.colors.secondary]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.workoutCard}
+      >
+        <View style={styles.workoutText}>
+          <Text style={styles.workoutTitle}>Daily Workout</Text>
+          <Text style={styles.workoutTime}>8:00 AM</Text>
+          <TouchableOpacity style={styles.workoutButton}>
+            <Text style={styles.workoutButtonText}>Start</Text>
+          </TouchableOpacity>
+        </View>
+        <Image source={require('../../assets/images/react-logo.png')} style={styles.workoutImage} />
+      </LinearGradient>
+
+      <View style={styles.progressSection}>
+        <Svg width={size} height={size}>
+          <Circle
+            stroke="#e6e6e6"
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            strokeWidth={strokeWidth}
+            fill="none"
+          />
+          <Circle
+            stroke={theme.colors.primary}
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            strokeWidth={strokeWidth}
+            fill="none"
+            strokeDasharray={`${circumference} ${circumference}`}
+            strokeDashoffset={strokeDashoffset}
+            strokeLinecap="round"
+            rotation="-90"
+            origin={`${size / 2},${size / 2}`}
+          />
+        </Svg>
+        <View style={styles.progressLabel}>
+          <Text style={styles.progressPercent}>70%</Text>
+          <Text style={styles.progressText}>Completed</Text>
+        </View>
+      </View>
+
+      <View style={styles.statsRow}>
+        <View style={styles.statCard}>
+          <Text style={styles.statValue}>350</Text>
+          <Text style={styles.statLabel}>Cal</Text>
+        </View>
+        <View style={styles.statCard}>
+          <Text style={styles.statValue}>45m</Text>
+          <Text style={styles.statLabel}>Time</Text>
+        </View>
+        <View style={styles.statCard}>
+          <Text style={styles.statValue}>120</Text>
+          <Text style={styles.statLabel}>BPM</Text>
+        </View>
+      </View>
+    </Layout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    justifyContent: 'center',
+    marginBottom: 24,
+  },
+  greeting: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: theme.colors.text,
+  },
+  subtitle: {
+    marginTop: 4,
+    color: theme.colors.text,
+    opacity: 0.7,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+  },
+  workoutCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 20,
+    padding: 20,
+    marginBottom: 24,
+  },
+  workoutText: {
+    flex: 1,
+  },
+  workoutTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  workoutTime: {
+    color: '#fff',
+    marginBottom: 12,
+  },
+  workoutButton: {
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    alignSelf: 'flex-start',
+  },
+  workoutButtonText: {
+    color: theme.colors.primary,
+    fontWeight: '600',
+  },
+  workoutImage: {
+    width: 80,
+    height: 80,
+  },
+  progressSection: {
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  progressLabel: {
+    position: 'absolute',
+    top: '35%',
+    alignItems: 'center',
+  },
+  progressPercent: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: theme.colors.text,
+  },
+  progressText: {
+    marginTop: 4,
+    color: theme.colors.text,
+    opacity: 0.7,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  statCard: {
+    flex: 1,
+    backgroundColor: '#fff',
+    marginHorizontal: 4,
+    borderRadius: 16,
+    paddingVertical: 16,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  statValue: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: theme.colors.text,
+  },
+  statLabel: {
+    marginTop: 4,
+    color: theme.colors.text,
+    opacity: 0.7,
   },
 });
 

--- a/components/CameraScreen.js
+++ b/components/CameraScreen.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unresolved */
 import React, { useState, useEffect } from 'react';
 import { View, Text, TouchableOpacity, Image, ActivityIndicator, Alert, StatusBar } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -6,6 +5,8 @@ import { Camera } from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import { styles } from '../constants/styles';
+import Layout from './Layout';
+import { theme } from '../constants/theme';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 export default function CameraScreen({ photos, setPhotos, loading, setLoading }) {
@@ -202,7 +203,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
   }
 
   return (
-    <View style={styles.container}>
+    <Layout>
       <StatusBar barStyle="light-content" />
       <View style={styles.modernHeader}>
         <Text style={styles.modernHeaderTitle}>Capture Progress</Text>
@@ -213,7 +214,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
       {loading ? (
         <View style={styles.loadingContainer}>
           <View style={styles.loadingCard}>
-            <ActivityIndicator size="large" color="#4285f4" />
+            <ActivityIndicator size="large" color={theme.colors.primary} />
             <Text style={styles.loadingTitle}>Analyzing Your Progress</Text>
             <Text style={styles.loadingSubtext}>AI is comparing your photos...</Text>
             <View style={styles.loadingDots}>
@@ -249,7 +250,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
           )}
         </View>
       )}
-    </View>
+    </Layout>
   );
 }
 

--- a/components/CameraScreen.js
+++ b/components/CameraScreen.js
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Camera } from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
+import { Feather } from '@expo/vector-icons';
 import { styles } from '../constants/styles';
 import Layout from './Layout';
 import { theme } from '../constants/theme';
@@ -175,7 +176,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
         </TouchableOpacity>
         <View style={styles.heroImageContainer}>
           <View style={styles.heroImageBackground}>
-            <Text style={styles.heroImagePlaceholder}>💪</Text>
+            <Feather name="activity" size={80} color="#000" style={styles.heroImagePlaceholder} />
             <Text style={styles.heroImageText}>Progress Photo</Text>
           </View>
         </View>
@@ -228,7 +229,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
         <View style={styles.modernCameraContent}>
           <TouchableOpacity style={styles.modernCameraButton} onPress={takePhoto} activeOpacity={0.8}>
             <View style={styles.modernCameraIcon}>
-              <Text style={styles.cameraIconText}>📸</Text>
+              <Feather name="camera" size={30} color="#fff" />
             </View>
             <Text style={styles.modernCameraButtonText}>Take Progress Photo</Text>
           </TouchableOpacity>

--- a/components/HelloWave.tsx
+++ b/components/HelloWave.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { StyleSheet } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -8,7 +9,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { ThemedText } from '@/components/ThemedText';
 
 export function HelloWave() {
   const rotationAnimation = useSharedValue(0);
@@ -26,15 +26,13 @@ export function HelloWave() {
 
   return (
     <Animated.View style={animatedStyle}>
-      <ThemedText style={styles.text}>👋</ThemedText>
+      <Feather name="hand" size={28} color="#000" style={styles.icon} />
     </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
-  text: {
-    fontSize: 28,
-    lineHeight: 32,
+  icon: {
     marginTop: -6,
   },
 });

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { styles } from '../constants/styles';
+import { theme } from '../constants/theme';
+
+export default function Layout({ children }) {
+  return (
+    <LinearGradient
+      colors={[theme.colors.primary, theme.colors.secondary]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.appBackground}
+    >
+      <SafeAreaView style={styles.appContainer}>{children}</SafeAreaView>
+    </LinearGradient>
+  );
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,18 +1,11 @@
 import React from 'react';
-import { SafeAreaView } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import { SafeAreaView, View } from 'react-native';
 import { styles } from '../constants/styles';
-import { theme } from '../constants/theme';
 
 export default function Layout({ children }) {
   return (
-    <LinearGradient
-      colors={[theme.colors.primary, theme.colors.secondary]}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={styles.appBackground}
-    >
-      <SafeAreaView style={styles.appContainer}>{children}</SafeAreaView>
-    </LinearGradient>
+    <SafeAreaView style={[styles.appBackground, { backgroundColor: '#fff' }]}>
+      <View style={styles.appContainer}>{children}</View>
+    </SafeAreaView>
   );
 }

--- a/components/ProfileScreen.js
+++ b/components/ProfileScreen.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, TextInput, StatusBar, Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { LinearGradient } from 'expo-linear-gradient';
+import { Feather } from '@expo/vector-icons';
 import { styles } from '../constants/styles';
 import Layout from './Layout';
 import { theme } from '../constants/theme';
@@ -28,7 +28,7 @@ export default function ProfileScreen({ photos }) {
     try {
       await AsyncStorage.setItem('fitnessGoal', newGoal);
       setGoal(newGoal);
-      Alert.alert('🎯 Goal Saved!', 'Your AI analysis will now be personalized to your goal.');
+      Alert.alert('Goal Saved!', 'Your AI analysis will now be personalized to your goal.');
     } catch (error) {
       console.error('Error saving goal:', error);
     }
@@ -44,33 +44,36 @@ export default function ProfileScreen({ photos }) {
 
   return (
     <Layout>
-      <StatusBar barStyle="light-content" />
-      <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.gradientHeader}>
+      <StatusBar barStyle="dark-content" />
+      <View style={styles.gradientHeader}>
         <Text style={styles.headerTitle}>Your Profile</Text>
         <Text style={styles.headerSubtitle}>Track your transformation</Text>
-      </LinearGradient>
+      </View>
 
       <ScrollView style={styles.profileScrollView} showsVerticalScrollIndicator={false}>
         <View style={styles.statsCard}>
           <Text style={styles.sectionTitle}>Journey Statistics</Text>
           <View style={styles.statsGrid}>
             <View style={styles.statItem}>
-              <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.statCircle}>
+              <View style={[styles.statCircle, { backgroundColor: theme.colors.primary }]}>
                 <Text style={styles.statNumber}>{photos.length}</Text>
-              </LinearGradient>
+              </View>
               <Text style={styles.statLabel}>Progress Photos</Text>
             </View>
             <View style={styles.statItem}>
-              <LinearGradient colors={['#f093fb', '#f5576c']} style={styles.statCircle}>
+              <View style={[styles.statCircle, { backgroundColor: '#f5576c' }]}>
                 <Text style={styles.statNumber}>{getJourneyDays()}</Text>
-              </LinearGradient>
+              </View>
               <Text style={styles.statLabel}>Days Tracking</Text>
             </View>
           </View>
         </View>
 
         <View style={styles.goalCard}>
-          <Text style={styles.sectionTitle}>🎯 Fitness Goal</Text>
+          <View style={styles.sectionTitleRow}>
+            <Feather name="target" size={20} color={theme.colors.text} />
+            <Text style={styles.sectionTitleRowText}>Fitness Goal</Text>
+          </View>
           <View style={styles.goalInputContainer}>
             <TextInput
               style={styles.goalInput}
@@ -82,25 +85,29 @@ export default function ProfileScreen({ photos }) {
             />
           </View>
           <TouchableOpacity style={styles.saveGoalButton} onPress={() => saveGoal(goal)} activeOpacity={0.8}>
-            <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.saveGoalGradient}>
-              <Text style={styles.saveGoalButtonText}>💾 Save Goal</Text>
-            </LinearGradient>
+            <Text style={styles.saveGoalButtonText}>Save Goal</Text>
           </TouchableOpacity>
-          <Text style={styles.goalHint}>💡 Setting a goal helps AI provide personalized feedback!</Text>
+          <View style={styles.goalHintRow}>
+            <Feather name="info" size={16} color="#666" />
+            <Text style={styles.goalHint}>Setting a goal helps AI provide personalized feedback!</Text>
+          </View>
         </View>
 
         <View style={styles.tipsCard}>
-          <Text style={styles.sectionTitle}>📸 Photography Tips</Text>
+          <View style={styles.sectionTitleRow}>
+            <Feather name="camera" size={20} color={theme.colors.text} />
+            <Text style={styles.sectionTitleRowText}>Photography Tips</Text>
+          </View>
           <View style={styles.tipsList}>
             {[
-              { icon: '📍', text: 'Use the same location every time' },
-              { icon: '💡', text: 'Keep lighting consistent' },
-              { icon: '👕', text: 'Wear similar clothing' },
-              { icon: '⏰', text: 'Take photos at the same time' },
-              { icon: '🧍', text: 'Maintain the same pose' },
+              { icon: 'map-pin', text: 'Use the same location every time' },
+              { icon: 'sun', text: 'Keep lighting consistent' },
+              { icon: 'shopping-bag', text: 'Wear similar clothing' },
+              { icon: 'clock', text: 'Take photos at the same time' },
+              { icon: 'user', text: 'Maintain the same pose' },
             ].map((tip, index) => (
               <View key={index} style={styles.tipItem}>
-                <Text style={styles.tipIcon}>{tip.icon}</Text>
+                <Feather name={tip.icon} size={20} color={theme.colors.primary} style={styles.tipIcon} />
                 <Text style={styles.tipText}>{tip.text}</Text>
               </View>
             ))}

--- a/components/ProfileScreen.js
+++ b/components/ProfileScreen.js
@@ -1,9 +1,10 @@
-/* eslint-disable import/no-unresolved */
 import React, { useState, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, TextInput, StatusBar, Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import { styles } from '../constants/styles';
+import Layout from './Layout';
+import { theme } from '../constants/theme';
 
 export default function ProfileScreen({ photos }) {
   const [goal, setGoal] = useState('');
@@ -42,9 +43,9 @@ export default function ProfileScreen({ photos }) {
   };
 
   return (
-    <View style={styles.container}>
+    <Layout>
       <StatusBar barStyle="light-content" />
-      <LinearGradient colors={['#4285f4', '#1e3c72']} style={styles.gradientHeader}>
+      <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.gradientHeader}>
         <Text style={styles.headerTitle}>Your Profile</Text>
         <Text style={styles.headerSubtitle}>Track your transformation</Text>
       </LinearGradient>
@@ -54,7 +55,7 @@ export default function ProfileScreen({ photos }) {
           <Text style={styles.sectionTitle}>Journey Statistics</Text>
           <View style={styles.statsGrid}>
             <View style={styles.statItem}>
-              <LinearGradient colors={['#4285f4', '#1e3c72']} style={styles.statCircle}>
+              <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.statCircle}>
                 <Text style={styles.statNumber}>{photos.length}</Text>
               </LinearGradient>
               <Text style={styles.statLabel}>Progress Photos</Text>
@@ -81,7 +82,7 @@ export default function ProfileScreen({ photos }) {
             />
           </View>
           <TouchableOpacity style={styles.saveGoalButton} onPress={() => saveGoal(goal)} activeOpacity={0.8}>
-            <LinearGradient colors={['#11998e', '#38ef7d']} style={styles.saveGoalGradient}>
+            <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.saveGoalGradient}>
               <Text style={styles.saveGoalButtonText}>💾 Save Goal</Text>
             </LinearGradient>
           </TouchableOpacity>
@@ -106,7 +107,7 @@ export default function ProfileScreen({ photos }) {
           </View>
         </View>
       </ScrollView>
-    </View>
+    </Layout>
   );
 }
 

--- a/components/ProgressScreen.js
+++ b/components/ProgressScreen.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, ScrollView, Image, TouchableOpacity, Alert, StatusBar } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
-import { LinearGradient } from 'expo-linear-gradient';
+import { Feather } from '@expo/vector-icons';
 import { styles } from '../constants/styles';
 import Layout from './Layout';
 import { theme } from '../constants/theme';
@@ -75,8 +75,8 @@ export default function ProgressScreen({ photos, setPhotos }) {
 
   return (
     <Layout>
-      <StatusBar barStyle="light-content" />
-      <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.gradientHeader}>
+      <StatusBar barStyle="dark-content" />
+      <View style={styles.gradientHeader}>
         <Text style={styles.headerTitle}>Your Journey</Text>
         <Text style={styles.headerSubtitle}>
           {photos.length} {photos.length === 1 ? 'milestone' : 'milestones'} captured
@@ -86,12 +86,17 @@ export default function ProgressScreen({ photos, setPhotos }) {
             style={[styles.compareToggle, compareMode && styles.compareToggleActive]}
             onPress={toggleCompareMode}
           >
+            {compareMode ? (
+              <Feather name="x" size={16} color={compareMode ? '#fff' : theme.colors.primary} />
+            ) : (
+              <Feather name="bar-chart-2" size={16} color={theme.colors.primary} />
+            )}
             <Text style={[styles.compareToggleText, compareMode && styles.compareToggleTextActive]}>
-              {compareMode ? '✕ Cancel' : '📊 Compare'}
+              {compareMode ? 'Cancel' : 'Compare'}
             </Text>
           </TouchableOpacity>
         )}
-      </LinearGradient>
+      </View>
 
       {compareMode && selectedPhotos.length === 2 && (
         <View style={styles.comparisonContainer}>
@@ -116,7 +121,7 @@ export default function ProgressScreen({ photos, setPhotos }) {
         {photos.length === 0 ? (
           <View style={styles.emptyStateContainer}>
             <View style={styles.emptyStateCard}>
-              <Text style={styles.emptyStateIcon}>📷</Text>
+              <Feather name="camera" size={40} color={theme.colors.primary} style={styles.emptyStateIcon} />
               <Text style={styles.emptyStateTitle}>No Progress Yet</Text>
               <Text style={styles.emptyStateText}>
                 Start your journey by taking your first progress photo
@@ -132,10 +137,10 @@ export default function ProgressScreen({ photos, setPhotos }) {
               <View style={styles.compareInstructionsContainer}>
                 <Text style={styles.compareInstructions}>
                   {selectedPhotos.length === 0
-                    ? '👆 Select two photos to compare'
+                    ? 'Select two photos to compare'
                     : selectedPhotos.length === 1
-                    ? '👆 Select one more photo'
-                    : '✨ Comparison ready! Tap photos to change selection'}
+                    ? 'Select one more photo'
+                    : 'Comparison ready! Tap photos to change selection'}
                 </Text>
               </View>
             )}
@@ -161,15 +166,12 @@ export default function ProgressScreen({ photos, setPhotos }) {
                   )}
                   <View style={styles.photoImageContainer}>
                     <Image source={{ uri: photo.uri }} style={styles.photoImage} />
-                    <LinearGradient
-                      colors={['transparent', 'rgba(0,0,0,0.7)']}
-                      style={styles.photoGradientOverlay}
-                    >
+                    <View style={[styles.photoGradientOverlay, { backgroundColor: 'rgba(0,0,0,0.6)' }]}> 
                       <View style={styles.photoHeader}>
                         <Text style={styles.photoNumber}>#{photos.length - index}</Text>
                         <Text style={styles.photoDate}>{formatDate(photo.timestamp)}</Text>
                       </View>
-                    </LinearGradient>
+                    </View>
                   </View>
                   {!compareMode && photo.analysis && (
                     <View style={styles.analysisContainer}>

--- a/components/ProgressScreen.js
+++ b/components/ProgressScreen.js
@@ -1,10 +1,11 @@
-/* eslint-disable import/no-unresolved */
 import React, { useState } from 'react';
 import { View, Text, ScrollView, Image, TouchableOpacity, Alert, StatusBar } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
 import { LinearGradient } from 'expo-linear-gradient';
 import { styles } from '../constants/styles';
+import Layout from './Layout';
+import { theme } from '../constants/theme';
 
 export default function ProgressScreen({ photos, setPhotos }) {
   const [compareMode, setCompareMode] = useState(false);
@@ -73,9 +74,9 @@ export default function ProgressScreen({ photos, setPhotos }) {
   };
 
   return (
-    <View style={styles.container}>
+    <Layout>
       <StatusBar barStyle="light-content" />
-      <LinearGradient colors={['#4285f4', '#1e3c72']} style={styles.gradientHeader}>
+      <LinearGradient colors={[theme.colors.primary, theme.colors.secondary]} style={styles.gradientHeader}>
         <Text style={styles.headerTitle}>Your Journey</Text>
         <Text style={styles.headerSubtitle}>
           {photos.length} {photos.length === 1 ? 'milestone' : 'milestones'} captured
@@ -181,7 +182,7 @@ export default function ProgressScreen({ photos, setPhotos }) {
           </>
         )}
       </ScrollView>
-    </View>
+    </Layout>
   );
 }
 

--- a/constants/styles.js
+++ b/constants/styles.js
@@ -62,7 +62,6 @@ export const styles = StyleSheet.create({
     elevation: 10,
   },
   heroImagePlaceholder: {
-    fontSize: 80,
     marginBottom: 10,
   },
   heroImageText: {
@@ -228,6 +227,7 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 20,
     borderBottomLeftRadius: 25,
     borderBottomRightRadius: 25,
+    backgroundColor: '#fff',
   },
   headerTitle: {
     fontSize: 28,
@@ -400,22 +400,27 @@ export const styles = StyleSheet.create({
     padding: 20,
   },
   compareToggle: {
-    backgroundColor: 'rgba(255,255,255,0.2)',
-    paddingHorizontal: 20,
-    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
     borderRadius: 25,
     alignSelf: 'center',
+    borderWidth: 1,
+    borderColor: theme.colors.primary,
   },
   compareToggleActive: {
-    backgroundColor: 'rgba(255,59,48,0.9)',
+    backgroundColor: theme.colors.primary,
   },
   compareToggleText: {
-    color: 'white',
+    color: theme.colors.primary,
     fontSize: 14,
     fontWeight: '600',
+    marginLeft: 6,
   },
   compareToggleTextActive: {
-    color: 'white',
+    color: '#fff',
   },
 
   // Comparison Styles
@@ -517,7 +522,6 @@ export const styles = StyleSheet.create({
     width: '90%',
   },
   emptyStateIcon: {
-    fontSize: 60,
     marginBottom: 20,
   },
   emptyStateTitle: {
@@ -663,6 +667,17 @@ export const styles = StyleSheet.create({
     color: '#333',
     textAlign: 'center',
   },
+  sectionTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  sectionTitleRowText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#333',
+    marginLeft: 8,
+  },
   statsGrid: {
     flexDirection: 'row',
     justifyContent: 'space-around',
@@ -723,23 +738,28 @@ export const styles = StyleSheet.create({
   },
   saveGoalButton: {
     borderRadius: 15,
-    overflow: 'hidden',
     marginBottom: 10,
-  },
-  saveGoalGradient: {
     padding: 15,
     alignItems: 'center',
+    backgroundColor: theme.colors.primary,
   },
   saveGoalButtonText: {
     color: 'white',
     fontSize: 16,
     fontWeight: 'bold',
   },
+  goalHintRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 10,
+  },
   goalHint: {
     fontSize: 14,
     color: '#666',
     textAlign: 'center',
     fontStyle: 'italic',
+    marginLeft: 6,
   },
 
   // Tips Section
@@ -766,7 +786,6 @@ export const styles = StyleSheet.create({
     borderRadius: 12,
   },
   tipIcon: {
-    fontSize: 20,
     marginRight: 15,
   },
   tipText: {

--- a/constants/styles.js
+++ b/constants/styles.js
@@ -1,10 +1,20 @@
 import { StyleSheet } from 'react-native';
+import { theme } from './theme';
 
 export const styles = StyleSheet.create({
+  // App wide layout
+  appBackground: {
+    flex: 1,
+  },
+  appContainer: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+
   // Base Layouts
   container: {
     flex: 1,
-    backgroundColor: '#f8f9fa',
+    backgroundColor: theme.colors.background,
   },
 
   // Welcome Screen Styles

--- a/constants/theme.js
+++ b/constants/theme.js
@@ -1,0 +1,8 @@
+export const theme = {
+  colors: {
+    primary: '#92A3FD',
+    secondary: '#9DCEFF',
+    background: '#FFFFFF',
+    text: '#1F2937',
+  },
+};

--- a/scripts/reset-project.js
+++ b/scripts/reset-project.js
@@ -50,7 +50,7 @@ const moveDirectories = async (userInput) => {
     if (userInput === "y") {
       // Create the app-example directory
       await fs.promises.mkdir(exampleDirPath, { recursive: true });
-      console.log(`📁 /${exampleDir} directory created.`);
+      console.log(`/${exampleDir} directory created.`);
     }
 
     // Move old directories to new app-example directory or delete them
@@ -60,32 +60,32 @@ const moveDirectories = async (userInput) => {
         if (userInput === "y") {
           const newDirPath = path.join(root, exampleDir, dir);
           await fs.promises.rename(oldDirPath, newDirPath);
-          console.log(`➡️ /${dir} moved to /${exampleDir}/${dir}.`);
+          console.log(`/${dir} moved to /${exampleDir}/${dir}.`);
         } else {
           await fs.promises.rm(oldDirPath, { recursive: true, force: true });
-          console.log(`❌ /${dir} deleted.`);
+          console.log(`/${dir} deleted.`);
         }
       } else {
-        console.log(`➡️ /${dir} does not exist, skipping.`);
+        console.log(`/${dir} does not exist, skipping.`);
       }
     }
 
     // Create new /app directory
     const newAppDirPath = path.join(root, newAppDir);
     await fs.promises.mkdir(newAppDirPath, { recursive: true });
-    console.log("\n📁 New /app directory created.");
+    console.log("\n/app directory created.");
 
     // Create index.tsx
     const indexPath = path.join(newAppDirPath, "index.tsx");
     await fs.promises.writeFile(indexPath, indexContent);
-    console.log("📄 app/index.tsx created.");
+    console.log("app/index.tsx created.");
 
     // Create _layout.tsx
     const layoutPath = path.join(newAppDirPath, "_layout.tsx");
     await fs.promises.writeFile(layoutPath, layoutContent);
-    console.log("📄 app/_layout.tsx created.");
+    console.log("app/_layout.tsx created.");
 
-    console.log("\n✅ Project reset complete. Next steps:");
+    console.log("\nProject reset complete. Next steps:");
     console.log(
       `1. Run \`npx expo start\` to start a development server.\n2. Edit app/index.tsx to edit the main screen.${
         userInput === "y"


### PR DESCRIPTION
## Summary
- craft home dashboard with greeting header, daily workout card, progress circle and stats row
- switch bottom nav to feather line icons and themed styling
- adjust theme colors for new gradient palette

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688f8d4478e08323b4577c6f0b7226f6