### PR TITLE
feat: overhaul home screen with photo progress layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,19 +1,32 @@
-import React, { useState, useEffect } from 'react';
-import { View, Text, Platform } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { NavigationContainer } from '@react-navigation/native';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
-import * as FileSystem from 'expo-file-system';
-import { Feather } from '@expo/vector-icons';
+import React, { useState, useEffect } from "react";
+import { View, Text, Platform, StyleSheet } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { NavigationContainer } from "@react-navigation/native";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import * as FileSystem from "expo-file-system";
+import { Feather } from "@expo/vector-icons";
 
-import CameraScreen from './components/CameraScreen';
-import ProgressScreen from './components/ProgressScreen';
-import ProfileScreen from './components/ProfileScreen';
-import { styles } from './constants/styles';
-import { theme } from './constants/theme';
+import CameraScreen from "./components/CameraScreen";
+import ProgressScreen from "./components/ProgressScreen";
+import ProfileScreen from "./components/ProfileScreen";
+import { theme } from "./constants/theme";
 
 const Tab = createBottomTabNavigator();
+
+const tabStyles = StyleSheet.create({
+  tabIcon: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  tabIconFocused: {
+    backgroundColor: "rgba(66, 133, 244, 0.1)",
+    transform: [{ scale: 1.1 }],
+  },
+});
 
 export default function App() {
   const [photos, setPhotos] = useState([]);
@@ -21,13 +34,13 @@ export default function App() {
 
   useEffect(() => {
     loadPhotos();
-    console.log('App Documents Directory:', FileSystem.documentDirectory);
-    console.log('App Cache Directory:', FileSystem.cacheDirectory);
+    console.log("App Documents Directory:", FileSystem.documentDirectory);
+    console.log("App Cache Directory:", FileSystem.cacheDirectory);
   }, []);
 
   const loadPhotos = async () => {
     try {
-      const savedPhotos = await AsyncStorage.getItem('progressPhotos');
+      const savedPhotos = await AsyncStorage.getItem("progressPhotos");
       if (savedPhotos) {
         const parsedPhotos = JSON.parse(savedPhotos);
         const validPhotos = [];
@@ -37,19 +50,25 @@ export default function App() {
             if (fileInfo.exists) {
               validPhotos.push(photo);
             } else {
-              console.log('Photo file not found, removing from list:', photo.uri);
+              console.log(
+                "Photo file not found, removing from list:",
+                photo.uri,
+              );
             }
           } catch (error) {
-            console.log('Error checking photo file:', error);
+            console.log("Error checking photo file:", error);
           }
         }
         if (validPhotos.length !== parsedPhotos.length) {
-          await AsyncStorage.setItem('progressPhotos', JSON.stringify(validPhotos));
+          await AsyncStorage.setItem(
+            "progressPhotos",
+            JSON.stringify(validPhotos),
+          );
         }
         setPhotos(validPhotos);
       }
     } catch (error) {
-      console.error('Error loading photos:', error);
+      console.error("Error loading photos:", error);
     }
   };
 
@@ -59,27 +78,24 @@ export default function App() {
         <Tab.Navigator
           screenOptions={{
             tabBarActiveTintColor: theme.colors.primary,
-            tabBarInactiveTintColor: '#8E8E93',
+            tabBarInactiveTintColor: "#8E8E93",
             headerShown: false,
             tabBarStyle: {
               backgroundColor: theme.colors.background,
-              borderTopColor: 'transparent',
+              borderTopColor: "transparent",
               elevation: 10,
-              shadowColor: '#000',
-              shadowOffset: { width: 0, height: -2 },
-              shadowOpacity: 0.1,
-              shadowRadius: 10,
+              boxShadow: "0px -2px 10px rgba(0,0,0,0.1)",
               // Dynamic height and padding based on platform
-              height: Platform.OS === 'ios' ? 90 : 80,
-              paddingBottom: Platform.OS === 'ios' ? 25 : 15,
+              height: Platform.OS === "ios" ? 90 : 80,
+              paddingBottom: Platform.OS === "ios" ? 25 : 15,
               paddingTop: 10,
               // Ensure tab bar stays above system navigation
-              position: 'relative',
+              position: "relative",
             },
             tabBarLabelStyle: {
               fontSize: 12,
-              fontWeight: '600',
-              marginBottom: Platform.OS === 'ios' ? 5 : 8,
+              fontWeight: "600",
+              marginBottom: Platform.OS === "ios" ? 5 : 8,
             },
             // Add safe area handling to tab bar items
             tabBarItemStyle: {
@@ -91,7 +107,12 @@ export default function App() {
             name="Camera"
             options={{
               tabBarIcon: ({ color, size, focused }) => (
-                <View style={[styles.tabIcon, focused && styles.tabIconFocused]}>
+                <View
+                  style={[
+                    tabStyles.tabIcon,
+                    focused && tabStyles.tabIconFocused,
+                  ]}
+                >
                   <Feather name="camera" size={size} color={color} />
                 </View>
               ),
@@ -110,7 +131,12 @@ export default function App() {
             name="Progress"
             options={{
               tabBarIcon: ({ color, size, focused }) => (
-                <View style={[styles.tabIcon, focused && styles.tabIconFocused]}>
+                <View
+                  style={[
+                    tabStyles.tabIcon,
+                    focused && tabStyles.tabIconFocused,
+                  ]}
+                >
                   <Feather name="bar-chart-2" size={size} color={color} />
                 </View>
               ),
@@ -122,7 +148,12 @@ export default function App() {
             name="Profile"
             options={{
               tabBarIcon: ({ color, size, focused }) => (
-                <View style={[styles.tabIcon, focused && styles.tabIconFocused]}>
+                <View
+                  style={[
+                    tabStyles.tabIcon,
+                    focused && tabStyles.tabIconFocused,
+                  ]}
+                >
                   <Feather name="user" size={size} color={color} />
                 </View>
               ),

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -83,7 +83,7 @@ export default function TabLayout() {
           options={{
             title: "Camera",
             tabBarIcon: ({ color, size }) => (
-              <Feather name="image" size={size} color={color} />
+              <Feather name="camera" size={size} color={color} />
             ),
           }}
         />

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,10 @@
-import React, { createContext, useState, useEffect } from 'react';
-import { Tabs } from 'expo-router';
-import { Feather } from '@expo/vector-icons';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as FileSystem from 'expo-file-system';
-import { theme } from '@/constants/theme';
+import React, { createContext, useState, useEffect } from "react";
+import { Tabs } from "expo-router";
+import { Feather } from "@expo/vector-icons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as FileSystem from "expo-file-system";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { theme } from "@/constants/theme";
 
 export const PhotoContext = createContext({
   photos: [],
@@ -15,6 +16,7 @@ export const PhotoContext = createContext({
 export default function TabLayout() {
   const [photos, setPhotos] = useState([]);
   const [loading, setLoading] = useState(false);
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     loadPhotos();
@@ -22,7 +24,7 @@ export default function TabLayout() {
 
   const loadPhotos = async () => {
     try {
-      const savedPhotos = await AsyncStorage.getItem('progressPhotos');
+      const savedPhotos = await AsyncStorage.getItem("progressPhotos");
       if (savedPhotos) {
         const parsedPhotos = JSON.parse(savedPhotos);
         const validPhotos = [];
@@ -37,12 +39,15 @@ export default function TabLayout() {
           }
         }
         if (validPhotos.length !== parsedPhotos.length) {
-          await AsyncStorage.setItem('progressPhotos', JSON.stringify(validPhotos));
+          await AsyncStorage.setItem(
+            "progressPhotos",
+            JSON.stringify(validPhotos),
+          );
         }
         setPhotos(validPhotos);
       }
     } catch (error) {
-      console.error('Error loading photos:', error);
+      console.error("Error loading photos:", error);
     }
   };
 
@@ -54,41 +59,50 @@ export default function TabLayout() {
           headerShown: false,
           tabBarShowLabel: false,
           tabBarActiveTintColor: theme.colors.primary,
-          tabBarInactiveTintColor: '#9AA1B9',
+          tabBarInactiveTintColor: "#9AA1B9",
           tabBarStyle: {
-            backgroundColor: '#fff',
+            backgroundColor: "#fff",
             borderTopWidth: 0,
             elevation: 5,
-            height: 60,
+            height: 60 + insets.bottom,
+            paddingBottom: insets.bottom,
           },
         }}
       >
         <Tabs.Screen
           name="homepage"
           options={{
-            title: 'Home',
-            tabBarIcon: ({ color, size }) => <Feather name="home" size={size} color={color} />,
+            title: "Home",
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="home" size={size} color={color} />
+            ),
           }}
         />
         <Tabs.Screen
           name="camera"
           options={{
-            title: 'Camera',
-            tabBarIcon: ({ color, size }) => <Feather name="camera" size={size} color={color} />,
+            title: "Camera",
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="camera" size={size} color={color} />
+            ),
           }}
         />
         <Tabs.Screen
           name="progress"
           options={{
-            title: 'Progress',
-            tabBarIcon: ({ color, size }) => <Feather name="bar-chart-2" size={size} color={color} />,
+            title: "Progress",
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="bar-chart-2" size={size} color={color} />
+            ),
           }}
         />
         <Tabs.Screen
           name="profile"
           options={{
-            title: 'Profile',
-            tabBarIcon: ({ color, size }) => <Feather name="user" size={size} color={color} />,
+            title: "Profile",
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="user" size={size} color={color} />
+            ),
           }}
         />
       </Tabs>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -83,7 +83,7 @@ export default function TabLayout() {
           options={{
             title: "Camera",
             tabBarIcon: ({ color, size }) => (
-              <Feather name="camera" size={size} color={color} />
+              <Feather name="image" size={size} color={color} />
             ),
           }}
         />

--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -1,8 +1,15 @@
-import React, { useContext } from 'react';
-import ProgressScreen from '@/components/ProgressScreen';
-import { PhotoContext } from './_layout';
+import React, { useContext } from "react";
+import CameraScreen from "@/components/CameraScreen";
+import { PhotoContext } from "./_layout";
 
 export default function CameraPage() {
-  const { photos, setPhotos } = useContext(PhotoContext);
-  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
+  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
+  return (
+    <CameraScreen
+      photos={photos}
+      setPhotos={setPhotos}
+      loading={loading}
+      setLoading={setLoading}
+    />
+  );
 }

--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -1,15 +1,8 @@
 import React, { useContext } from "react";
-import CameraScreen from "@/components/CameraScreen";
+import ProgressScreen from "@/components/ProgressScreen";
 import { PhotoContext } from "./_layout";
 
 export default function CameraPage() {
-  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
-  return (
-    <CameraScreen
-      photos={photos}
-      setPhotos={setPhotos}
-      loading={loading}
-      setLoading={setLoading}
-    />
-  );
+  const { photos, setPhotos } = useContext(PhotoContext);
+  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
 }

--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -1,15 +1,8 @@
 import React, { useContext } from 'react';
-import CameraScreen from '@/components/CameraScreen';
+import ProgressScreen from '@/components/ProgressScreen';
 import { PhotoContext } from './_layout';
 
 export default function CameraPage() {
-  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
-  return (
-    <CameraScreen
-      photos={photos}
-      setPhotos={setPhotos}
-      loading={loading}
-      setLoading={setLoading}
-    />
-  );
+  const { photos, setPhotos } = useContext(PhotoContext);
+  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
 }

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   StyleSheet,
 } from "react-native";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 
 const Icon = ({
   children,
@@ -25,6 +26,7 @@ const Plus = (props: any) => <Icon {...props}>＋</Icon>;
 
 const PhotoProgressApp = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
+  const tabBarHeight = useBottomTabBarHeight();
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentDate(new Date()), 1000);
@@ -43,7 +45,12 @@ const PhotoProgressApp = () => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: tabBarHeight + 24 },
+        ]}
+      >
         {/* Status Bar */}
         <View style={styles.statusBar}>
           <Text style={styles.statusTime}>9:41</Text>
@@ -169,8 +176,6 @@ const PhotoProgressApp = () => {
             </Text>
           </TouchableOpacity>
         </View>
-
-        <View style={styles.bottomSpace} />
       </ScrollView>
     </SafeAreaView>
   );
@@ -323,5 +328,4 @@ const styles = StyleSheet.create({
   },
   captureButtonIcon: { fontSize: 20, color: "#fff", marginRight: 8 },
   captureButtonText: { color: "#fff", fontWeight: "500" },
-  bottomSpace: { height: 96 },
 });

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,243 +1,282 @@
-import React from 'react';
-import { View, Text, Image, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
-// eslint-disable-next-line import/no-unresolved
-import Svg, { Circle } from 'react-native-svg';
-import { Feather } from '@expo/vector-icons';
+import React, { useState, useEffect } from "react";
 
-import Layout from '@/components/Layout';
-import { theme } from '@/constants/theme';
+// Simple emoji-based icons to avoid external dependencies
+const Icon = ({ children, className }) => (
+  <span className={className}>{children}</span>
+);
+const Camera = (props) => <Icon {...props}>📷</Icon>;
+const TrendingUp = (props) => <Icon {...props}>📈</Icon>;
+const Calendar = (props) => <Icon {...props}>📅</Icon>;
+const Target = (props) => <Icon {...props}>🎯</Icon>;
+const Search = (props) => <Icon {...props}>🔍</Icon>;
+const Settings = (props) => <Icon {...props}>⚙️</Icon>;
+const MoreHorizontal = (props) => <Icon {...props}>⋯</Icon>;
+const Plus = (props) => <Icon {...props}>＋</Icon>;
+const Users = (props) => <Icon {...props}>👥</Icon>;
+const Clock = (props) => <Icon {...props}>🕒</Icon>;
 
-const workouts = [
-  {
-    id: 1,
-    title: 'Full Body',
-    time: '8:00 AM',
-    image: require('../../assets/images/react-logo.png'),
-  },
-  {
-    id: 2,
-    title: 'Yoga Stretch',
-    time: '9:00 AM',
-    image: require('../../assets/images/react-logo.png'),
-  },
-  {
-    id: 3,
-    title: 'HIIT Blast',
-    time: '10:00 AM',
-    image: require('../../assets/images/react-logo.png'),
-  },
-];
+const PhotoProgressApp = () => {
+  const [currentDate, setCurrentDate] = useState(new Date());
 
-export default function Homepage() {
-  const progress = 0.7;
-  const size = 120;
-  const strokeWidth = 12;
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const strokeDashoffset = circumference * (1 - progress);
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentDate(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const formatDate = (date) => {
+    return date.toLocaleDateString("en-US", {
+      weekday: "long",
+      day: "numeric",
+      month: "short",
+    });
+  };
+
+  const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const today = currentDate.getDay();
 
   return (
-    <Layout>
-      <ScrollView showsVerticalScrollIndicator={false}>
-        <View style={styles.header}>
-          <View>
-            <Text style={styles.greeting}>Hello, John</Text>
-            <Text style={styles.subtitle}>Ready for your workout?</Text>
-          </View>
-          <Image source={require('../../assets/images/icon.png')} style={styles.avatar} />
-        </View>
-
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.workoutScroll}
-        >
-          {workouts.map((item) => (
-            <View key={item.id} style={styles.workoutCard}>
-              <View style={styles.workoutInfo}>
-                <Text style={styles.workoutTitle}>{item.title}</Text>
-                <Text style={styles.workoutTime}>{item.time}</Text>
-                <TouchableOpacity style={styles.playButton}>
-                  <Feather name="play" size={16} color="#fff" />
-                </TouchableOpacity>
-              </View>
-              <Image source={item.image} style={styles.workoutImage} />
-            </View>
-          ))}
-        </ScrollView>
-
-        <View style={styles.progressSection}>
-          <Svg width={size} height={size}>
-            <Circle
-              stroke="#e6e6e6"
-              cx={size / 2}
-              cy={size / 2}
-              r={radius}
-              strokeWidth={strokeWidth}
-              fill="none"
-            />
-            <Circle
-              stroke={theme.colors.primary}
-              cx={size / 2}
-              cy={size / 2}
-              r={radius}
-              strokeWidth={strokeWidth}
-              fill="none"
-              strokeDasharray={`${circumference} ${circumference}`}
-              strokeDashoffset={strokeDashoffset}
-              strokeLinecap="round"
-              rotation="-90"
-              origin={`${size / 2},${size / 2}`}
-            />
-          </Svg>
-          <View style={styles.progressLabel}>
-            <Text style={styles.progressPercent}>70%</Text>
-            <Text style={styles.progressText}>Completed</Text>
-          </View>
-        </View>
-
-        <View style={styles.statsGrid}>
-          <View style={styles.statCard}>
-            <Feather name="fire" size={24} color={theme.colors.primary} />
-            <View style={styles.statInfo}>
-              <Text style={styles.statValue}>350</Text>
-              <Text style={styles.statLabel}>Calories</Text>
-            </View>
-          </View>
-          <View style={styles.statCard}>
-            <Feather name="clock" size={24} color={theme.colors.primary} />
-            <View style={styles.statInfo}>
-              <Text style={styles.statValue}>45m</Text>
-              <Text style={styles.statLabel}>Time</Text>
-            </View>
-          </View>
-          <View style={styles.statCard}>
-            <Feather name="heart" size={24} color={theme.colors.primary} />
-            <View style={styles.statInfo}>
-              <Text style={styles.statValue}>120</Text>
-              <Text style={styles.statLabel}>BPM</Text>
-            </View>
-          </View>
-        </View>
-      </ScrollView>
-    </Layout>
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-sm mx-auto bg-gray-50 min-h-screen">
+        {/* Status Bar */}
+        <div className="flex justify-between items-center px-6 pt-3 pb-2">
+          <div className="text-sm font-medium">9:41</div>
+          <div className="flex items-center gap-1">
+            <div className="flex gap-1">
+              <div className="w-1 h-1 bg-gray-900 rounded-full"></div>
+              <div className="w-1 h-1 bg-gray-900 rounded-full"></div>
+              <div className="w-1 h-1 bg-gray-900 rounded-full"></div>
+              <div className="w-1 h-1 bg-gray-400 rounded-full"></div>
+            </div>
+            <div className="ml-2 text-sm">📶</div>
+            <div className="text-sm">🔋</div>
+          </div>
+        </div>
+        {/* Header */}
+        <div className="flex justify-between items-start px-6 pt-4 pb-6">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-full overflow-hidden">
+              <img
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E"
+                alt="Profile"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <div>
+              <p className="text-gray-600 text-sm">Hello, John</p>
+              <p className="text-gray-900 font-medium">
+                {formatDate(currentDate)}
+              </p>
+            </div>
+          </div>
+          <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm">
+            <Search className="w-5 h-5 text-gray-600" />
+          </button>
+        </div>
+        {/* Daily Challenge Card */}
+        <div className="px-6 mb-6">
+          <div className="bg-gradient-to-br from-blue-400 via-blue-500 to-green-500 rounded-3xl p-6 relative overflow-hidden">
+            {/* 3D Elements */}
+            <div className="absolute top-4 right-4 w-16 h-16 opacity-30">
+              <div className="w-8 h-8 bg-yellow-400 rounded-full absolute top-0 right-0"></div>
+              <div className="w-10 h-10 bg-orange-500 rounded-lg absolute bottom-0 left-0 transform rotate-12"></div>
+              <div className="w-6 h-6 bg-green-500 rounded-full absolute top-3 left-2"></div>
+            </div>
+            <div className="relative z-10">
+              <h2 className="text-white text-2xl font-bold mb-1">CaptureFit</h2>
+              <h2 className="text-white text-2xl font-bold mb-2">challenge</h2>
+              <p className="text-blue-100 text-sm mb-4">
+                AI-powered progress tracking
+              </p>
+              {/* Mini Avatars */}
+              <div className="flex -space-x-2 mb-4">
+                <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center text-xs font-bold text-blue-600">
+                  J
+                </div>
+                <div className="w-8 h-8 bg-yellow-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
+                  M
+                </div>
+                <div className="w-8 h-8 bg-green-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
+                  S
+                </div>
+                <div className="w-8 h-8 bg-pink-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
+                  A
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* Week Calendar */}
+        <div className="px-6 mb-6">
+          <div className="flex justify-between items-center">
+            {weekDays.map((day, index) => {
+              const dayNumber = 22 + index;
+              const isToday = index === today;
+              return (
+                <div key={day} className="text-center">
+                  <p className="text-gray-500 text-xs mb-2">{day}</p>
+                  <div
+                    className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-medium ${isToday ? "bg-gray-900 text-white" : "bg-white text-gray-600 border border-gray-200"}`}
+                  >
+                    {dayNumber}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        {/* Your Progress Section */}
+        <div className="px-6 mb-6">
+          <h3 className="text-gray-900 text-lg font-semibold mb-4">
+            Your progress
+          </h3>
+          <div className="grid grid-cols-2 gap-4">
+            {/* Photo Analysis Card */}
+            <div className="bg-gradient-to-br from-orange-200 to-orange-300 rounded-3xl p-5 relative overflow-hidden">
+              <div className="absolute -top-2 -right-2 w-12 h-12 bg-white/20 rounded-full"></div>
+              <div className="relative z-10">
+                <div className="mb-3">
+                  <Camera className="w-6 h-6 text-orange-800 mb-2" />
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    CaptureFit
+                  </h4>
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    Analysis
+                  </h4>
+                </div>
+                <p className="text-orange-800 text-xs mb-3">AI body tracking</p>
+                <p className="text-orange-900 text-xs">📍 Ready to capture</p>
+              </div>
+            </div>
+            {/* Progress Stats Card */}
+            <div className="bg-gradient-to-br from-blue-100 to-blue-200 rounded-3xl p-5 relative overflow-hidden">
+              <div className="absolute -bottom-2 -right-2 w-16 h-16 bg-white/20 rounded-full"></div>
+              <div className="relative z-10">
+                <div className="mb-3">
+                  <TrendingUp className="w-6 h-6 text-blue-800 mb-2" />
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    Progress
+                  </h4>
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    Stats
+                  </h4>
+                </div>
+                <p className="text-blue-800 text-xs mb-3">12 day streak</p>
+                <p className="text-blue-900 text-xs">📊 View analytics</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* Today's Metrics */}
+        <div className="px-6 mb-6">
+          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-gray-900 font-semibold">
+                Today&apos;s Progress
+              </h3>
+              <button>
+                <MoreHorizontal className="w-5 h-5 text-gray-400" />
+              </button>
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="w-12 h-12 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
+                  <span className="text-lg">💪</span>
+                </div>
+                <p className="text-gray-900 font-semibold text-lg">+8%</p>
+                <p className="text-gray-500 text-xs">Muscle def.</p>
+              </div>
+              <div className="text-center">
+                <div className="w-12 h-12 bg-orange-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
+                  <span className="text-lg">🔥</span>
+                </div>
+                <p className="text-gray-900 font-semibold text-lg">-2.1%</p>
+                <p className="text-gray-500 text-xs">Body fat</p>
+              </div>
+              <div className="text-center">
+                <div className="w-12 h-12 bg-blue-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
+                  <span className="text-lg">📏</span>
+                </div>
+                <p className="text-gray-900 font-semibold text-lg">89</p>
+                <p className="text-gray-500 text-xs">Total pics</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* Photo Comparison Section */}
+        <div className="px-6 mb-6">
+          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
+            <h3 className="text-gray-900 font-semibold mb-4">
+              Photo Comparison
+            </h3>
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <div className="aspect-[3/4] bg-gray-100 rounded-2xl flex items-center justify-center mb-3 relative overflow-hidden">
+                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-green-50"></div>
+                  <div className="relative z-10 text-center">
+                    <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+                    <p className="text-gray-500 text-sm font-medium">
+                      7 days ago
+                    </p>
+                  </div>
+                </div>
+                <p className="text-center text-gray-600 text-sm font-medium">
+                  Before
+                </p>
+              </div>
+              <div className="flex items-center px-2">
+                <div className="w-8 h-0.5 bg-gray-200 rounded-full"></div>
+              </div>
+              <div className="flex-1">
+                <div className="aspect-[3/4] bg-gray-50 rounded-2xl flex items-center justify-center mb-3 border-2 border-dashed border-gray-200 relative overflow-hidden">
+                  <div className="absolute inset-0 bg-gradient-to-br from-green-50 to-blue-50"></div>
+                  <div className="relative z-10 text-center">
+                    <Plus className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+                    <p className="text-gray-500 text-sm font-medium">
+                      Take photo
+                    </p>
+                  </div>
+                </div>
+                <p className="text-center text-gray-600 text-sm font-medium">
+                  Today
+                </p>
+              </div>
+            </div>
+            <button className="w-full bg-gray-900 text-white rounded-2xl py-4 flex items-center justify-center gap-2 mt-4 font-medium">
+              <Camera className="w-5 h-5" />
+              <span>Capture with CaptureFit</span>
+            </button>
+          </div>
+        </div>
+        {/* Bottom Navigation */}
+        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm">
+          <div className="bg-gray-900 mx-4 mb-6 rounded-3xl px-6 py-4">
+            <div className="flex justify-around items-center">
+              <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center">
+                <div className="w-6 h-6 bg-gray-900 rounded-lg"></div>
+              </button>
+              <button className="p-2">
+                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex items-center justify-center">
+                  <div className="w-2 h-2 bg-gray-400 rounded-sm"></div>
+                </div>
+              </button>
+              <button className="p-2">
+                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex flex-col gap-0.5 p-1">
+                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
+                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
+                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
+                </div>
+              </button>
+              <button className="p-2">
+                <div className="w-6 h-6 bg-gray-400 rounded-full"></div>
+              </button>
+            </div>
+          </div>
+        </div>
+        {/* Extra spacing for bottom nav */}
+        <div className="h-24"></div>
+      </div>
+    </div>
   );
-}
+};
 
-const styles = StyleSheet.create({
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 24,
-  },
-  greeting: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: theme.colors.text,
-  },
-  subtitle: {
-    marginTop: 4,
-    color: theme.colors.text,
-    opacity: 0.7,
-  },
-  avatar: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-  },
-  workoutScroll: {
-    paddingBottom: 16,
-  },
-  workoutCard: {
-    backgroundColor: '#fff',
-    borderRadius: 16,
-    padding: 20,
-    marginRight: 16,
-    flexDirection: 'row',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  workoutInfo: {
-    flex: 1,
-  },
-  workoutTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: theme.colors.text,
-    marginBottom: 4,
-  },
-  workoutTime: {
-    color: '#6B7280',
-    marginBottom: 12,
-  },
-  playButton: {
-    backgroundColor: theme.colors.primary,
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  workoutImage: {
-    width: 80,
-    height: 80,
-    marginLeft: 10,
-  },
-  progressSection: {
-    alignItems: 'center',
-    marginBottom: 24,
-  },
-  progressLabel: {
-    position: 'absolute',
-    top: '35%',
-    alignItems: 'center',
-  },
-  progressPercent: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: theme.colors.text,
-  },
-  progressText: {
-    marginTop: 4,
-    color: theme.colors.text,
-    opacity: 0.7,
-  },
-  statsGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-  },
-  statCard: {
-    width: '48%',
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#fff',
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 6,
-    elevation: 3,
-  },
-  statInfo: {
-    marginLeft: 12,
-  },
-  statValue: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: theme.colors.text,
-  },
-  statLabel: {
-    marginTop: 4,
-    color: theme.colors.text,
-    opacity: 0.7,
-  },
-});
-
+export default PhotoProgressApp;

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,37 +1,114 @@
-import React, { useState, useEffect } from "react";
-import {
-  SafeAreaView,
-  View,
-  Text,
-  Image,
-  TouchableOpacity,
-  ScrollView,
-  StyleSheet,
-} from "react-native";
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
+/* eslint-env browser */
+import React, { useEffect, useRef, useState } from "react";
 
+// Simple emoji-based icons used as placeholders for lucide-react icons
 const Icon = ({
   children,
-  style,
+  className,
 }: {
   children: React.ReactNode;
-  style?: any;
-}) => <Text style={style}>{children}</Text>;
+  className?: string;
+}) => <span className={className}>{children}</span>;
+
 const Camera = (props: any) => <Icon {...props}>📷</Icon>;
 const TrendingUp = (props: any) => <Icon {...props}>📈</Icon>;
 const Calendar = (props: any) => <Icon {...props}>📅</Icon>;
 const Search = (props: any) => <Icon {...props}>🔍</Icon>;
 const MoreHorizontal = (props: any) => <Icon {...props}>⋯</Icon>;
 const Plus = (props: any) => <Icon {...props}>＋</Icon>;
+const X = (props: any) => <Icon {...props}>✕</Icon>;
 
 const PhotoProgressApp = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
-  const tabBarHeight = useBottomTabBarHeight();
+  const [showCamera, setShowCamera] = useState(false);
+  const [capturedImage, setCapturedImage] = useState<string | null>(null);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentDate(new Date()), 1000);
     return () => clearInterval(timer);
   }, []);
+
+  const startCamera = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: "user",
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+        },
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+      }
+      setShowCamera(true);
+    } catch (error) {
+      console.error("Error accessing camera:", error);
+      alert("Unable to access camera. Please check permissions.");
+    }
+  };
+
+  const capturePhoto = () => {
+    if (videoRef.current && canvasRef.current) {
+      const canvas = canvasRef.current;
+      const video = videoRef.current;
+      const context = canvas.getContext("2d");
+      if (!context) return;
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      context.drawImage(video, 0, 0);
+      const imageData = canvas.toDataURL("image/jpeg", 0.8);
+      setCapturedImage(imageData);
+      stopCamera();
+      void sendToAPI(imageData);
+    }
+  };
+
+  const stopCamera = () => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+    }
+    setShowCamera(false);
+  };
+
+  const sendToAPI = async (imageData: string) => {
+    setIsAnalyzing(true);
+    try {
+      const response = await fetch(imageData);
+      const blob = await response.blob();
+      const formData = new FormData();
+      formData.append("image", blob, "progress-photo.jpg");
+      formData.append("userId", "john_123");
+      formData.append("timestamp", new Date().toISOString());
+      const apiResponse = await fetch("/api/analyze-progress", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Authorization: "Bearer YOUR_API_TOKEN",
+        },
+      });
+      if (apiResponse.ok) {
+        const analysisResult = await apiResponse.json();
+        console.log("Analysis result:", analysisResult);
+        alert(`Photo uploaded successfully! Keep up the great progress.`);
+      } else {
+        throw new Error("API request failed");
+      }
+    } catch (error) {
+      console.error("Error sending to API:", error);
+      alert("Error analyzing photo. Please try again.");
+    } finally {
+      setIsAnalyzing(false);
+    }
+  };
+
+  const handleCameraClick = () => {
+    void startCamera();
+  };
 
   const formatDate = (date: Date) =>
     date.toLocaleDateString("en-US", {
@@ -44,288 +121,329 @@ const PhotoProgressApp = () => {
   const today = currentDate.getDay();
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <ScrollView
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: tabBarHeight + 24 },
-        ]}
-      >
-        {/* Status Bar */}
-        <View style={styles.statusBar}>
-          <Text style={styles.statusTime}>9:41</Text>
-          <Text style={styles.statusIcons}>●●●○ 📶 🔋</Text>
-        </View>
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-sm mx-auto bg-gray-50 min-h-screen relative">
+        {showCamera && (
+          <div className="fixed inset-0 bg-black z-50 flex flex-col">
+            <div className="flex justify-between items-center p-4 text-white">
+              <button onClick={stopCamera} className="p-2">
+                <X className="w-6 h-6" />
+              </button>
+              <h2 className="text-lg font-semibold">CaptureFit Camera</h2>
+              <div className="w-10" />
+            </div>
 
-        {/* Header */}
-        <View style={styles.header}>
-          <View style={styles.profileInfo}>
-            <Image
-              source={{
-                uri: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E",
-              }}
-              style={styles.avatar}
-            />
-            <View>
-              <Text style={styles.greeting}>Hello, John</Text>
-              <Text style={styles.dateText}>{formatDate(currentDate)}</Text>
-            </View>
-          </View>
-          <TouchableOpacity style={styles.searchButton}>
-            <Search style={styles.searchIcon} />
-          </TouchableOpacity>
-        </View>
+            <div className="flex-1 relative">
+              <video
+                ref={videoRef}
+                autoPlay
+                playsInline
+                className="w-full h-full object-cover"
+              />
 
-        {/* Daily Challenge Card */}
-        <View style={styles.challengeCard}>
-          <Camera style={styles.challengeIcon} />
-          <Text style={styles.challengeTitle}>CaptureFit challenge</Text>
-          <Text style={styles.challengeSub}>AI-powered progress tracking</Text>
-        </View>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="w-64 h-80 border-2 border-white/50 rounded-2xl flex items-center justify-center">
+                  <p className="text-white/70 text-sm text-center px-4">
+                    Position yourself within the frame for best results
+                  </p>
+                </div>
+              </div>
+            </div>
 
-        {/* Week Calendar */}
-        <View style={styles.weekRow}>
-          {weekDays.map((day, index) => {
-            const dayNumber = 22 + index;
-            const isToday = index === today;
-            return (
-              <View key={day} style={styles.weekItem}>
-                <Text style={styles.weekDay}>{day}</Text>
-                <View
-                  style={[styles.weekCircle, isToday && styles.weekCircleToday]}
-                >
-                  <Text
-                    style={[
-                      styles.weekNumber,
-                      isToday && styles.weekNumberToday,
-                    ]}
+            <div className="p-6 flex justify-center">
+              <button
+                onClick={capturePhoto}
+                className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-lg"
+                disabled={isAnalyzing}
+              >
+                <div className="w-16 h-16 bg-blue-500 rounded-full flex items-center justify-center">
+                  <Camera className="w-8 h-8 text-white" />
+                </div>
+              </button>
+            </div>
+
+            {isAnalyzing && (
+              <div className="absolute inset-0 bg-black/80 flex items-center justify-center">
+                <div className="text-center text-white">
+                  <div className="w-8 h-8 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+                  <p className="text-lg font-semibold">
+                    Analyzing your progress...
+                  </p>
+                  <p className="text-sm opacity-70">
+                    AI is processing your photo
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <canvas ref={canvasRef} style={{ display: "none" }} />
+        {capturedImage && (
+          <img src={capturedImage} alt="captured" className="hidden" />
+        )}
+
+        <div className="flex justify-between items-center px-6 pt-3 pb-2">
+          <div className="text-sm font-medium">9:41</div>
+          <div className="flex items-center gap-1">
+            <div className="flex gap-1">
+              <div className="w-1 h-1 bg-gray-900 rounded-full" />
+              <div className="w-1 h-1 bg-gray-900 rounded-full" />
+              <div className="w-1 h-1 bg-gray-900 rounded-full" />
+              <div className="w-1 h-1 bg-gray-400 rounded-full" />
+            </div>
+            <div className="ml-2 text-sm">📶</div>
+            <div className="text-sm">🔋</div>
+          </div>
+        </div>
+
+        <div className="flex justify-between items-start px-6 pt-4 pb-6">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-full overflow-hidden">
+              <img
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E"
+                alt="Profile"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <div>
+              <p className="text-gray-600 text-sm">Hello, John</p>
+              <p className="text-gray-900 font-medium">
+                {formatDate(currentDate)}
+              </p>
+            </div>
+          </div>
+          <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm">
+            <Search className="w-5 h-5 text-gray-600" />
+          </button>
+        </div>
+
+        <div className="px-6 mb-6">
+          <div className="bg-gradient-to-br from-blue-400 via-blue-500 to-green-500 rounded-3xl p-6 relative overflow-hidden">
+            <div className="absolute top-4 right-4 w-16 h-16 opacity-30">
+              <div className="w-8 h-8 bg-yellow-400 rounded-full absolute top-0 right-0" />
+              <div className="w-10 h-10 bg-orange-500 rounded-lg absolute bottom-0 left-0 transform rotate-12" />
+              <div className="w-6 h-6 bg-green-500 rounded-full absolute top-3 left-2" />
+            </div>
+
+            <div className="relative z-10">
+              <h2 className="text-white text-2xl font-bold mb-1">CaptureFit</h2>
+              <h2 className="text-white text-2xl font-bold mb-2">challenge</h2>
+              <p className="text-blue-100 text-sm mb-4">
+                Track your visual progress journey
+              </p>
+
+              <div className="flex -space-x-2 mb-4">
+                <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center text-xs font-bold text-blue-600">
+                  J
+                </div>
+                <div className="w-8 h-8 bg-yellow-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
+                  M
+                </div>
+                <div className="w-8 h-8 bg-green-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
+                  S
+                </div>
+                <div className="w-8 h-8 bg-pink-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
+                  A
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-6 mb-6">
+          <div className="flex justify-between items-center">
+            {weekDays.map((day, index) => {
+              const dayNumber = 22 + index;
+              const isToday = index === today;
+              return (
+                <div key={day} className="text-center">
+                  <p className="text-gray-500 text-xs mb-2">{day}</p>
+                  <div
+                    className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-medium ${
+                      isToday
+                        ? "bg-gray-900 text-white"
+                        : "bg-white text-gray-600 border border-gray-200"
+                    }`}
                   >
                     {dayNumber}
-                  </Text>
-                </View>
-              </View>
-            );
-          })}
-        </View>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
 
-        {/* Your Progress Section */}
-        <Text style={styles.sectionTitle}>Your progress</Text>
-        <View style={styles.progressRow}>
-          <View style={[styles.progressCard, styles.orangeCard]}>
-            <Camera style={styles.progressIcon} />
-            <Text style={styles.progressCardTitle}>CaptureFit Analysis</Text>
-            <Text style={styles.progressCardSub}>📍 Ready to capture</Text>
-          </View>
-          <View style={[styles.progressCard, styles.blueCard]}>
-            <TrendingUp style={styles.progressIcon} />
-            <Text style={styles.progressCardTitle}>Progress Stats</Text>
-            <Text style={styles.progressCardSub}>📊 View analytics</Text>
-          </View>
-        </View>
+        <div className="px-6 mb-6">
+          <h3 className="text-gray-900 text-lg font-semibold mb-4">
+            Your progress
+          </h3>
 
-        {/* Today's Metrics */}
-        <View style={styles.metricsCard}>
-          <View style={styles.metricsHeader}>
-            <Text style={styles.metricsTitle}>{`Today's Progress`}</Text>
-            <TouchableOpacity>
-              <MoreHorizontal style={styles.moreIcon} />
-            </TouchableOpacity>
-          </View>
-          <View style={styles.metricsRow}>
-            <View style={styles.metricItem}>
-              <Text style={styles.metricIcon}>💪</Text>
-              <Text style={styles.metricValue}>+8%</Text>
-              <Text style={styles.metricLabel}>Muscle def.</Text>
-            </View>
-            <View style={styles.metricItem}>
-              <Text style={styles.metricIcon}>🔥</Text>
-              <Text style={styles.metricValue}>-2.1%</Text>
-              <Text style={styles.metricLabel}>Body fat</Text>
-            </View>
-            <View style={styles.metricItem}>
-              <Text style={styles.metricIcon}>📏</Text>
-              <Text style={styles.metricValue}>89</Text>
-              <Text style={styles.metricLabel}>Total pics</Text>
-            </View>
-          </View>
-        </View>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-gradient-to-br from-orange-200 to-orange-300 rounded-3xl p-5 relative overflow-hidden">
+              <div className="absolute -top-2 -right-2 w-12 h-12 bg-white/20 rounded-full" />
+              <div className="relative z-10">
+                <div className="mb-3">
+                  <Camera className="w-6 h-6 text-orange-800 mb-2" />
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    CaptureFit
+                  </h4>
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    Analysis
+                  </h4>
+                </div>
+                <p className="text-orange-800 text-xs mb-3">
+                  Visual progress tracking
+                </p>
+                <p className="text-orange-900 text-xs">📸 Ready to capture</p>
+              </div>
+            </div>
 
-        {/* Photo Comparison */}
-        <View style={styles.comparisonCard}>
-          <Text style={styles.metricsTitle}>Photo Comparison</Text>
-          <View style={styles.comparisonRow}>
-            <View style={styles.comparisonItem}>
-              <View style={styles.comparisonBox}>
-                <Calendar style={styles.comparisonIcon} />
-                <Text style={styles.comparisonText}>7 days ago</Text>
-              </View>
-              <Text style={styles.comparisonLabel}>Before</Text>
-            </View>
-            <View style={styles.comparisonItem}>
-              <View style={[styles.comparisonBox, styles.dashedBox]}>
-                <Plus style={styles.comparisonIcon} />
-                <Text style={styles.comparisonText}>Take photo</Text>
-              </View>
-              <Text style={styles.comparisonLabel}>Today</Text>
-            </View>
-          </View>
-          <TouchableOpacity style={styles.captureButton}>
-            <Camera style={styles.captureButtonIcon} />
-            <Text style={styles.captureButtonText}>
-              Capture with CaptureFit
-            </Text>
-          </TouchableOpacity>
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+            <div className="bg-gradient-to-br from-blue-100 to-blue-200 rounded-3xl p-5 relative overflow-hidden">
+              <div className="absolute -bottom-2 -right-2 w-16 h-16 bg-white/20 rounded-full" />
+              <div className="relative z-10">
+                <div className="mb-3">
+                  <TrendingUp className="w-6 h-6 text-blue-800 mb-2" />
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    Progress
+                  </h4>
+                  <h4 className="text-gray-900 font-semibold text-base">
+                    Stats
+                  </h4>
+                </div>
+                <p className="text-blue-800 text-xs mb-3">2 week streak</p>
+                <p className="text-blue-900 text-xs">📊 View timeline</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-6 mb-6">
+          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-gray-900 font-semibold">
+                This Week’s Progress
+              </h3>
+              <button>
+                <MoreHorizontal className="w-5 h-5 text-gray-400" />
+              </button>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <div className="w-12 h-12 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
+                  <span className="text-lg">📸</span>
+                </div>
+                <p className="text-gray-900 font-semibold text-lg">2</p>
+                <p className="text-gray-500 text-xs">Photos taken</p>
+              </div>
+
+              <div className="text-center">
+                <div className="w-12 h-12 bg-blue-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
+                  <span className="text-lg">🔥</span>
+                </div>
+                <p className="text-gray-900 font-semibold text-lg">2</p>
+                <p className="text-gray-500 text-xs">Week streak</p>
+              </div>
+
+              <div className="text-center">
+                <div className="w-12 h-12 bg-orange-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
+                  <span className="text-lg">📅</span>
+                </div>
+                <p className="text-gray-900 font-semibold text-lg">14</p>
+                <p className="text-gray-500 text-xs">Days tracked</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="px-6 mb-6">
+          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
+            <h3 className="text-gray-900 font-semibold mb-4">
+              Visual Comparison
+            </h3>
+
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <div className="aspect-[3/4] bg-gray-100 rounded-2xl flex items-center justify-center mb-3 relative overflow-hidden">
+                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-green-50"></div>
+                  <div className="relative z-10 text-center">
+                    <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+                    <p className="text-gray-500 text-sm font-medium">
+                      Last week
+                    </p>
+                  </div>
+                </div>
+                <p className="text-center text-gray-600 text-sm font-medium">
+                  Before
+                </p>
+              </div>
+
+              <div className="flex items-center px-2">
+                <div className="w-8 h-0.5 bg-gray-200 rounded-full"></div>
+              </div>
+
+              <div className="flex-1">
+                <div
+                  className="aspect-[3/4] bg-gray-50 rounded-2xl flex items-center justify-center mb-3 border-2 border-dashed border-gray-200 relative overflow-hidden cursor-pointer"
+                  onClick={handleCameraClick}
+                >
+                  <div className="absolute inset-0 bg-gradient-to-br from-green-50 to-blue-50"></div>
+                  <div className="relative z-10 text-center">
+                    <Plus className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+                    <p className="text-gray-500 text-sm font-medium">
+                      This week
+                    </p>
+                  </div>
+                </div>
+                <p className="text-center text-gray-600 text-sm font-medium">
+                  This Week
+                </p>
+              </div>
+            </div>
+
+            <button
+              onClick={handleCameraClick}
+              className="w-full bg-gray-900 text-white rounded-2xl py-4 flex items-center justify-center gap-2 mt-4 font-medium hover:bg-gray-800 transition-colors"
+              disabled={isAnalyzing}
+            >
+              <Camera className="w-5 h-5" />
+              <span>
+                {isAnalyzing ? "Analyzing..." : "Capture with CaptureFit"}
+              </span>
+            </button>
+          </div>
+        </div>
+
+        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm">
+          <div className="bg-gray-900 mx-4 mb-6 rounded-3xl px-6 py-4">
+            <div className="flex justify-around items-center">
+              <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center">
+                <div className="w-6 h-6 bg-gray-900 rounded-lg"></div>
+              </button>
+              <button className="p-2">
+                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex items-center justify-center">
+                  <div className="w-2 h-2 bg-gray-400 rounded-sm"></div>
+                </div>
+              </button>
+              <button className="p-2">
+                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex flex-col gap-0.5 p-1">
+                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
+                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
+                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
+                </div>
+              </button>
+              <button className="p-2">
+                <div className="w-6 h-6 bg-gray-400 rounded-full"></div>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="h-24"></div>
+      </div>
+    </div>
   );
 };
 
 export default PhotoProgressApp;
-
-const styles = StyleSheet.create({
-  safeArea: { flex: 1, backgroundColor: "#F9FAFB" },
-  scrollContent: { padding: 24 },
-  statusBar: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    marginBottom: 16,
-  },
-  statusTime: { fontSize: 12, fontWeight: "500", color: "#111827" },
-  statusIcons: { fontSize: 12 },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 24,
-  },
-  profileInfo: { flexDirection: "row", alignItems: "center" },
-  avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 12 },
-  greeting: { fontSize: 14, color: "#6B7280" },
-  dateText: { fontSize: 16, fontWeight: "500", color: "#111827" },
-  searchButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-    shadowColor: "#000",
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  searchIcon: { fontSize: 20, color: "#4B5563" },
-  challengeCard: {
-    backgroundColor: "#3B82F6",
-    borderRadius: 24,
-    padding: 24,
-    marginBottom: 24,
-  },
-  challengeIcon: { fontSize: 24, marginBottom: 8 },
-  challengeTitle: { color: "#fff", fontSize: 20, fontWeight: "700" },
-  challengeSub: { color: "#DBEAFE", fontSize: 12, marginTop: 4 },
-  weekRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    marginBottom: 24,
-  },
-  weekItem: { alignItems: "center" },
-  weekDay: { color: "#6B7280", fontSize: 12, marginBottom: 4 },
-  weekCircle: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: "#E5E7EB",
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#fff",
-  },
-  weekCircleToday: { backgroundColor: "#111827", borderColor: "#111827" },
-  weekNumber: { color: "#4B5563", fontSize: 14 },
-  weekNumberToday: { color: "#fff" },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: "#111827",
-    marginBottom: 16,
-  },
-  progressRow: { flexDirection: "row", marginBottom: 24 },
-  progressCard: {
-    flex: 1,
-    borderRadius: 24,
-    padding: 20,
-  },
-  orangeCard: {
-    backgroundColor: "#FED7AA",
-    marginRight: 8,
-  },
-  blueCard: { backgroundColor: "#BFDBFE", marginLeft: 8 },
-  progressIcon: { fontSize: 24, marginBottom: 8 },
-  progressCardTitle: { fontSize: 16, fontWeight: "600", color: "#111827" },
-  progressCardSub: { fontSize: 12, color: "#374151", marginTop: 4 },
-  metricsCard: {
-    backgroundColor: "#fff",
-    borderRadius: 24,
-    padding: 24,
-    borderWidth: 1,
-    borderColor: "#F3F4F6",
-    marginBottom: 24,
-  },
-  metricsHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 16,
-  },
-  metricsTitle: { fontSize: 18, fontWeight: "600", color: "#111827" },
-  moreIcon: { fontSize: 16, color: "#9CA3AF" },
-  metricsRow: { flexDirection: "row", justifyContent: "space-between" },
-  metricItem: { flex: 1, alignItems: "center" },
-  metricIcon: { fontSize: 24, marginBottom: 8 },
-  metricValue: { fontSize: 18, fontWeight: "600", color: "#111827" },
-  metricLabel: { fontSize: 12, color: "#6B7280", marginTop: 4 },
-  comparisonCard: {
-    backgroundColor: "#fff",
-    borderRadius: 24,
-    padding: 24,
-    borderWidth: 1,
-    borderColor: "#F3F4F6",
-    marginBottom: 24,
-  },
-  comparisonRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    marginBottom: 16,
-  },
-  comparisonItem: { flex: 1, alignItems: "center" },
-  comparisonBox: {
-    width: "100%",
-    aspectRatio: 3 / 4,
-    backgroundColor: "#F3F4F6",
-    borderRadius: 16,
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: 8,
-  },
-  dashedBox: {
-    borderWidth: 2,
-    borderColor: "#E5E7EB",
-    borderStyle: "dashed",
-    backgroundColor: "#F9FAFB",
-  },
-  comparisonIcon: { fontSize: 32, marginBottom: 8, color: "#9CA3AF" },
-  comparisonText: { fontSize: 14, color: "#6B7280" },
-  comparisonLabel: { fontSize: 14, color: "#4B5563" },
-  captureButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "#111827",
-    borderRadius: 16,
-    paddingVertical: 12,
-  },
-  captureButtonIcon: { fontSize: 20, color: "#fff", marginRight: 8 },
-  captureButtonText: { color: "#fff", fontWeight: "500" },
-});

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,19 +1,27 @@
 import React, { useState, useEffect } from "react";
+import {
+  SafeAreaView,
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from "react-native";
 
-// Simple emoji-based icons to avoid external dependencies
-const Icon = ({ children, className }) => (
-  <span className={className}>{children}</span>
-);
-const Camera = (props) => <Icon {...props}>📷</Icon>;
-const TrendingUp = (props) => <Icon {...props}>📈</Icon>;
-const Calendar = (props) => <Icon {...props}>📅</Icon>;
-const Target = (props) => <Icon {...props}>🎯</Icon>;
-const Search = (props) => <Icon {...props}>🔍</Icon>;
-const Settings = (props) => <Icon {...props}>⚙️</Icon>;
-const MoreHorizontal = (props) => <Icon {...props}>⋯</Icon>;
-const Plus = (props) => <Icon {...props}>＋</Icon>;
-const Users = (props) => <Icon {...props}>👥</Icon>;
-const Clock = (props) => <Icon {...props}>🕒</Icon>;
+const Icon = ({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: any;
+}) => <Text style={style}>{children}</Text>;
+const Camera = (props: any) => <Icon {...props}>📷</Icon>;
+const TrendingUp = (props: any) => <Icon {...props}>📈</Icon>;
+const Calendar = (props: any) => <Icon {...props}>📅</Icon>;
+const Search = (props: any) => <Icon {...props}>🔍</Icon>;
+const MoreHorizontal = (props: any) => <Icon {...props}>⋯</Icon>;
+const Plus = (props: any) => <Icon {...props}>＋</Icon>;
 
 const PhotoProgressApp = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -23,260 +31,297 @@ const PhotoProgressApp = () => {
     return () => clearInterval(timer);
   }, []);
 
-  const formatDate = (date) => {
-    return date.toLocaleDateString("en-US", {
+  const formatDate = (date: Date) =>
+    date.toLocaleDateString("en-US", {
       weekday: "long",
       day: "numeric",
       month: "short",
     });
-  };
 
   const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const today = currentDate.getDay();
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-sm mx-auto bg-gray-50 min-h-screen">
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
         {/* Status Bar */}
-        <div className="flex justify-between items-center px-6 pt-3 pb-2">
-          <div className="text-sm font-medium">9:41</div>
-          <div className="flex items-center gap-1">
-            <div className="flex gap-1">
-              <div className="w-1 h-1 bg-gray-900 rounded-full"></div>
-              <div className="w-1 h-1 bg-gray-900 rounded-full"></div>
-              <div className="w-1 h-1 bg-gray-900 rounded-full"></div>
-              <div className="w-1 h-1 bg-gray-400 rounded-full"></div>
-            </div>
-            <div className="ml-2 text-sm">📶</div>
-            <div className="text-sm">🔋</div>
-          </div>
-        </div>
+        <View style={styles.statusBar}>
+          <Text style={styles.statusTime}>9:41</Text>
+          <Text style={styles.statusIcons}>●●●○ 📶 🔋</Text>
+        </View>
+
         {/* Header */}
-        <div className="flex justify-between items-start px-6 pt-4 pb-6">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 rounded-full overflow-hidden">
-              <img
-                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E"
-                alt="Profile"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <div>
-              <p className="text-gray-600 text-sm">Hello, John</p>
-              <p className="text-gray-900 font-medium">
-                {formatDate(currentDate)}
-              </p>
-            </div>
-          </div>
-          <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm">
-            <Search className="w-5 h-5 text-gray-600" />
-          </button>
-        </div>
+        <View style={styles.header}>
+          <View style={styles.profileInfo}>
+            <Image
+              source={{
+                uri: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E",
+              }}
+              style={styles.avatar}
+            />
+            <View>
+              <Text style={styles.greeting}>Hello, John</Text>
+              <Text style={styles.dateText}>{formatDate(currentDate)}</Text>
+            </View>
+          </View>
+          <TouchableOpacity style={styles.searchButton}>
+            <Search style={styles.searchIcon} />
+          </TouchableOpacity>
+        </View>
+
         {/* Daily Challenge Card */}
-        <div className="px-6 mb-6">
-          <div className="bg-gradient-to-br from-blue-400 via-blue-500 to-green-500 rounded-3xl p-6 relative overflow-hidden">
-            {/* 3D Elements */}
-            <div className="absolute top-4 right-4 w-16 h-16 opacity-30">
-              <div className="w-8 h-8 bg-yellow-400 rounded-full absolute top-0 right-0"></div>
-              <div className="w-10 h-10 bg-orange-500 rounded-lg absolute bottom-0 left-0 transform rotate-12"></div>
-              <div className="w-6 h-6 bg-green-500 rounded-full absolute top-3 left-2"></div>
-            </div>
-            <div className="relative z-10">
-              <h2 className="text-white text-2xl font-bold mb-1">CaptureFit</h2>
-              <h2 className="text-white text-2xl font-bold mb-2">challenge</h2>
-              <p className="text-blue-100 text-sm mb-4">
-                AI-powered progress tracking
-              </p>
-              {/* Mini Avatars */}
-              <div className="flex -space-x-2 mb-4">
-                <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center text-xs font-bold text-blue-600">
-                  J
-                </div>
-                <div className="w-8 h-8 bg-yellow-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
-                  M
-                </div>
-                <div className="w-8 h-8 bg-green-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
-                  S
-                </div>
-                <div className="w-8 h-8 bg-pink-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
-                  A
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <View style={styles.challengeCard}>
+          <Camera style={styles.challengeIcon} />
+          <Text style={styles.challengeTitle}>CaptureFit challenge</Text>
+          <Text style={styles.challengeSub}>AI-powered progress tracking</Text>
+        </View>
+
         {/* Week Calendar */}
-        <div className="px-6 mb-6">
-          <div className="flex justify-between items-center">
-            {weekDays.map((day, index) => {
-              const dayNumber = 22 + index;
-              const isToday = index === today;
-              return (
-                <div key={day} className="text-center">
-                  <p className="text-gray-500 text-xs mb-2">{day}</p>
-                  <div
-                    className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-medium ${isToday ? "bg-gray-900 text-white" : "bg-white text-gray-600 border border-gray-200"}`}
+        <View style={styles.weekRow}>
+          {weekDays.map((day, index) => {
+            const dayNumber = 22 + index;
+            const isToday = index === today;
+            return (
+              <View key={day} style={styles.weekItem}>
+                <Text style={styles.weekDay}>{day}</Text>
+                <View
+                  style={[styles.weekCircle, isToday && styles.weekCircleToday]}
+                >
+                  <Text
+                    style={[
+                      styles.weekNumber,
+                      isToday && styles.weekNumberToday,
+                    ]}
                   >
                     {dayNumber}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+
         {/* Your Progress Section */}
-        <div className="px-6 mb-6">
-          <h3 className="text-gray-900 text-lg font-semibold mb-4">
-            Your progress
-          </h3>
-          <div className="grid grid-cols-2 gap-4">
-            {/* Photo Analysis Card */}
-            <div className="bg-gradient-to-br from-orange-200 to-orange-300 rounded-3xl p-5 relative overflow-hidden">
-              <div className="absolute -top-2 -right-2 w-12 h-12 bg-white/20 rounded-full"></div>
-              <div className="relative z-10">
-                <div className="mb-3">
-                  <Camera className="w-6 h-6 text-orange-800 mb-2" />
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    CaptureFit
-                  </h4>
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    Analysis
-                  </h4>
-                </div>
-                <p className="text-orange-800 text-xs mb-3">AI body tracking</p>
-                <p className="text-orange-900 text-xs">📍 Ready to capture</p>
-              </div>
-            </div>
-            {/* Progress Stats Card */}
-            <div className="bg-gradient-to-br from-blue-100 to-blue-200 rounded-3xl p-5 relative overflow-hidden">
-              <div className="absolute -bottom-2 -right-2 w-16 h-16 bg-white/20 rounded-full"></div>
-              <div className="relative z-10">
-                <div className="mb-3">
-                  <TrendingUp className="w-6 h-6 text-blue-800 mb-2" />
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    Progress
-                  </h4>
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    Stats
-                  </h4>
-                </div>
-                <p className="text-blue-800 text-xs mb-3">12 day streak</p>
-                <p className="text-blue-900 text-xs">📊 View analytics</p>
-              </div>
-            </div>
-          </div>
-        </div>
+        <Text style={styles.sectionTitle}>Your progress</Text>
+        <View style={styles.progressRow}>
+          <View style={[styles.progressCard, styles.orangeCard]}>
+            <Camera style={styles.progressIcon} />
+            <Text style={styles.progressCardTitle}>CaptureFit Analysis</Text>
+            <Text style={styles.progressCardSub}>📍 Ready to capture</Text>
+          </View>
+          <View style={[styles.progressCard, styles.blueCard]}>
+            <TrendingUp style={styles.progressIcon} />
+            <Text style={styles.progressCardTitle}>Progress Stats</Text>
+            <Text style={styles.progressCardSub}>📊 View analytics</Text>
+          </View>
+        </View>
+
         {/* Today's Metrics */}
-        <div className="px-6 mb-6">
-          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-gray-900 font-semibold">
-                Today&apos;s Progress
-              </h3>
-              <button>
-                <MoreHorizontal className="w-5 h-5 text-gray-400" />
-              </button>
-            </div>
-            <div className="grid grid-cols-3 gap-4">
-              <div className="text-center">
-                <div className="w-12 h-12 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
-                  <span className="text-lg">💪</span>
-                </div>
-                <p className="text-gray-900 font-semibold text-lg">+8%</p>
-                <p className="text-gray-500 text-xs">Muscle def.</p>
-              </div>
-              <div className="text-center">
-                <div className="w-12 h-12 bg-orange-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
-                  <span className="text-lg">🔥</span>
-                </div>
-                <p className="text-gray-900 font-semibold text-lg">-2.1%</p>
-                <p className="text-gray-500 text-xs">Body fat</p>
-              </div>
-              <div className="text-center">
-                <div className="w-12 h-12 bg-blue-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
-                  <span className="text-lg">📏</span>
-                </div>
-                <p className="text-gray-900 font-semibold text-lg">89</p>
-                <p className="text-gray-500 text-xs">Total pics</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* Photo Comparison Section */}
-        <div className="px-6 mb-6">
-          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
-            <h3 className="text-gray-900 font-semibold mb-4">
-              Photo Comparison
-            </h3>
-            <div className="flex gap-4">
-              <div className="flex-1">
-                <div className="aspect-[3/4] bg-gray-100 rounded-2xl flex items-center justify-center mb-3 relative overflow-hidden">
-                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-green-50"></div>
-                  <div className="relative z-10 text-center">
-                    <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-                    <p className="text-gray-500 text-sm font-medium">
-                      7 days ago
-                    </p>
-                  </div>
-                </div>
-                <p className="text-center text-gray-600 text-sm font-medium">
-                  Before
-                </p>
-              </div>
-              <div className="flex items-center px-2">
-                <div className="w-8 h-0.5 bg-gray-200 rounded-full"></div>
-              </div>
-              <div className="flex-1">
-                <div className="aspect-[3/4] bg-gray-50 rounded-2xl flex items-center justify-center mb-3 border-2 border-dashed border-gray-200 relative overflow-hidden">
-                  <div className="absolute inset-0 bg-gradient-to-br from-green-50 to-blue-50"></div>
-                  <div className="relative z-10 text-center">
-                    <Plus className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-                    <p className="text-gray-500 text-sm font-medium">
-                      Take photo
-                    </p>
-                  </div>
-                </div>
-                <p className="text-center text-gray-600 text-sm font-medium">
-                  Today
-                </p>
-              </div>
-            </div>
-            <button className="w-full bg-gray-900 text-white rounded-2xl py-4 flex items-center justify-center gap-2 mt-4 font-medium">
-              <Camera className="w-5 h-5" />
-              <span>Capture with CaptureFit</span>
-            </button>
-          </div>
-        </div>
-        {/* Bottom Navigation */}
-        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm">
-          <div className="bg-gray-900 mx-4 mb-6 rounded-3xl px-6 py-4">
-            <div className="flex justify-around items-center">
-              <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center">
-                <div className="w-6 h-6 bg-gray-900 rounded-lg"></div>
-              </button>
-              <button className="p-2">
-                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex items-center justify-center">
-                  <div className="w-2 h-2 bg-gray-400 rounded-sm"></div>
-                </div>
-              </button>
-              <button className="p-2">
-                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex flex-col gap-0.5 p-1">
-                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
-                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
-                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
-                </div>
-              </button>
-              <button className="p-2">
-                <div className="w-6 h-6 bg-gray-400 rounded-full"></div>
-              </button>
-            </div>
-          </div>
-        </div>
-        {/* Extra spacing for bottom nav */}
-        <div className="h-24"></div>
-      </div>
-    </div>
+        <View style={styles.metricsCard}>
+          <View style={styles.metricsHeader}>
+            <Text style={styles.metricsTitle}>{`Today's Progress`}</Text>
+            <TouchableOpacity>
+              <MoreHorizontal style={styles.moreIcon} />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.metricsRow}>
+            <View style={styles.metricItem}>
+              <Text style={styles.metricIcon}>💪</Text>
+              <Text style={styles.metricValue}>+8%</Text>
+              <Text style={styles.metricLabel}>Muscle def.</Text>
+            </View>
+            <View style={styles.metricItem}>
+              <Text style={styles.metricIcon}>🔥</Text>
+              <Text style={styles.metricValue}>-2.1%</Text>
+              <Text style={styles.metricLabel}>Body fat</Text>
+            </View>
+            <View style={styles.metricItem}>
+              <Text style={styles.metricIcon}>📏</Text>
+              <Text style={styles.metricValue}>89</Text>
+              <Text style={styles.metricLabel}>Total pics</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Photo Comparison */}
+        <View style={styles.comparisonCard}>
+          <Text style={styles.metricsTitle}>Photo Comparison</Text>
+          <View style={styles.comparisonRow}>
+            <View style={styles.comparisonItem}>
+              <View style={styles.comparisonBox}>
+                <Calendar style={styles.comparisonIcon} />
+                <Text style={styles.comparisonText}>7 days ago</Text>
+              </View>
+              <Text style={styles.comparisonLabel}>Before</Text>
+            </View>
+            <View style={styles.comparisonItem}>
+              <View style={[styles.comparisonBox, styles.dashedBox]}>
+                <Plus style={styles.comparisonIcon} />
+                <Text style={styles.comparisonText}>Take photo</Text>
+              </View>
+              <Text style={styles.comparisonLabel}>Today</Text>
+            </View>
+          </View>
+          <TouchableOpacity style={styles.captureButton}>
+            <Camera style={styles.captureButtonIcon} />
+            <Text style={styles.captureButtonText}>
+              Capture with CaptureFit
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.bottomSpace} />
+      </ScrollView>
+    </SafeAreaView>
   );
 };
 
 export default PhotoProgressApp;
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: "#F9FAFB" },
+  scrollContent: { padding: 24 },
+  statusBar: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 16,
+  },
+  statusTime: { fontSize: 12, fontWeight: "500", color: "#111827" },
+  statusIcons: { fontSize: 12 },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  profileInfo: { flexDirection: "row", alignItems: "center" },
+  avatar: { width: 48, height: 48, borderRadius: 24, marginRight: 12 },
+  greeting: { fontSize: 14, color: "#6B7280" },
+  dateText: { fontSize: 16, fontWeight: "500", color: "#111827" },
+  searchButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  searchIcon: { fontSize: 20, color: "#4B5563" },
+  challengeCard: {
+    backgroundColor: "#3B82F6",
+    borderRadius: 24,
+    padding: 24,
+    marginBottom: 24,
+  },
+  challengeIcon: { fontSize: 24, marginBottom: 8 },
+  challengeTitle: { color: "#fff", fontSize: 20, fontWeight: "700" },
+  challengeSub: { color: "#DBEAFE", fontSize: 12, marginTop: 4 },
+  weekRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 24,
+  },
+  weekItem: { alignItems: "center" },
+  weekDay: { color: "#6B7280", fontSize: 12, marginBottom: 4 },
+  weekCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#fff",
+  },
+  weekCircleToday: { backgroundColor: "#111827", borderColor: "#111827" },
+  weekNumber: { color: "#4B5563", fontSize: 14 },
+  weekNumberToday: { color: "#fff" },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#111827",
+    marginBottom: 16,
+  },
+  progressRow: { flexDirection: "row", marginBottom: 24 },
+  progressCard: {
+    flex: 1,
+    borderRadius: 24,
+    padding: 20,
+  },
+  orangeCard: {
+    backgroundColor: "#FED7AA",
+    marginRight: 8,
+  },
+  blueCard: { backgroundColor: "#BFDBFE", marginLeft: 8 },
+  progressIcon: { fontSize: 24, marginBottom: 8 },
+  progressCardTitle: { fontSize: 16, fontWeight: "600", color: "#111827" },
+  progressCardSub: { fontSize: 12, color: "#374151", marginTop: 4 },
+  metricsCard: {
+    backgroundColor: "#fff",
+    borderRadius: 24,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: "#F3F4F6",
+    marginBottom: 24,
+  },
+  metricsHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  metricsTitle: { fontSize: 18, fontWeight: "600", color: "#111827" },
+  moreIcon: { fontSize: 16, color: "#9CA3AF" },
+  metricsRow: { flexDirection: "row", justifyContent: "space-between" },
+  metricItem: { flex: 1, alignItems: "center" },
+  metricIcon: { fontSize: 24, marginBottom: 8 },
+  metricValue: { fontSize: 18, fontWeight: "600", color: "#111827" },
+  metricLabel: { fontSize: 12, color: "#6B7280", marginTop: 4 },
+  comparisonCard: {
+    backgroundColor: "#fff",
+    borderRadius: 24,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: "#F3F4F6",
+    marginBottom: 24,
+  },
+  comparisonRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 16,
+  },
+  comparisonItem: { flex: 1, alignItems: "center" },
+  comparisonBox: {
+    width: "100%",
+    aspectRatio: 3 / 4,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 8,
+  },
+  dashedBox: {
+    borderWidth: 2,
+    borderColor: "#E5E7EB",
+    borderStyle: "dashed",
+    backgroundColor: "#F9FAFB",
+  },
+  comparisonIcon: { fontSize: 32, marginBottom: 8, color: "#9CA3AF" },
+  comparisonText: { fontSize: 14, color: "#6B7280" },
+  comparisonLabel: { fontSize: 14, color: "#4B5563" },
+  captureButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    paddingVertical: 12,
+  },
+  captureButtonIcon: { fontSize: 20, color: "#fff", marginRight: 8 },
+  captureButtonText: { color: "#fff", fontWeight: "500" },
+  bottomSpace: { height: 96 },
+});

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,114 +1,24 @@
-/* eslint-env browser */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from "react-native";
+import { Feather } from "@expo/vector-icons";
+import Layout from "@/components/Layout";
 
-// Simple emoji-based icons used as placeholders for lucide-react icons
-const Icon = ({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) => <span className={className}>{children}</span>;
+const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-const Camera = (props: any) => <Icon {...props}>📷</Icon>;
-const TrendingUp = (props: any) => <Icon {...props}>📈</Icon>;
-const Calendar = (props: any) => <Icon {...props}>📅</Icon>;
-const Search = (props: any) => <Icon {...props}>🔍</Icon>;
-const MoreHorizontal = (props: any) => <Icon {...props}>⋯</Icon>;
-const Plus = (props: any) => <Icon {...props}>＋</Icon>;
-const X = (props: any) => <Icon {...props}>✕</Icon>;
-
-const PhotoProgressApp = () => {
+export default function Homepage() {
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [showCamera, setShowCamera] = useState(false);
-  const [capturedImage, setCapturedImage] = useState<string | null>(null);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentDate(new Date()), 1000);
     return () => clearInterval(timer);
   }, []);
-
-  const startCamera = async () => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: {
-          facingMode: "user",
-          width: { ideal: 1280 },
-          height: { ideal: 720 },
-        },
-      });
-      streamRef.current = stream;
-      if (videoRef.current) {
-        videoRef.current.srcObject = stream;
-      }
-      setShowCamera(true);
-    } catch (error) {
-      console.error("Error accessing camera:", error);
-      alert("Unable to access camera. Please check permissions.");
-    }
-  };
-
-  const capturePhoto = () => {
-    if (videoRef.current && canvasRef.current) {
-      const canvas = canvasRef.current;
-      const video = videoRef.current;
-      const context = canvas.getContext("2d");
-      if (!context) return;
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      context.drawImage(video, 0, 0);
-      const imageData = canvas.toDataURL("image/jpeg", 0.8);
-      setCapturedImage(imageData);
-      stopCamera();
-      void sendToAPI(imageData);
-    }
-  };
-
-  const stopCamera = () => {
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => track.stop());
-    }
-    setShowCamera(false);
-  };
-
-  const sendToAPI = async (imageData: string) => {
-    setIsAnalyzing(true);
-    try {
-      const response = await fetch(imageData);
-      const blob = await response.blob();
-      const formData = new FormData();
-      formData.append("image", blob, "progress-photo.jpg");
-      formData.append("userId", "john_123");
-      formData.append("timestamp", new Date().toISOString());
-      const apiResponse = await fetch("/api/analyze-progress", {
-        method: "POST",
-        body: formData,
-        headers: {
-          Authorization: "Bearer YOUR_API_TOKEN",
-        },
-      });
-      if (apiResponse.ok) {
-        const analysisResult = await apiResponse.json();
-        console.log("Analysis result:", analysisResult);
-        alert(`Photo uploaded successfully! Keep up the great progress.`);
-      } else {
-        throw new Error("API request failed");
-      }
-    } catch (error) {
-      console.error("Error sending to API:", error);
-      alert("Error analyzing photo. Please try again.");
-    } finally {
-      setIsAnalyzing(false);
-    }
-  };
-
-  const handleCameraClick = () => {
-    void startCamera();
-  };
 
   const formatDate = (date: Date) =>
     date.toLocaleDateString("en-US", {
@@ -117,333 +27,313 @@ const PhotoProgressApp = () => {
       month: "short",
     });
 
-  const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const today = currentDate.getDay();
+  const todayIndex = currentDate.getDay();
+  const baseDay = 22;
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-sm mx-auto bg-gray-50 min-h-screen relative">
-        {showCamera && (
-          <div className="fixed inset-0 bg-black z-50 flex flex-col">
-            <div className="flex justify-between items-center p-4 text-white">
-              <button onClick={stopCamera} className="p-2">
-                <X className="w-6 h-6" />
-              </button>
-              <h2 className="text-lg font-semibold">CaptureFit Camera</h2>
-              <div className="w-10" />
-            </div>
+    <Layout paddingHorizontal={24} paddingVertical={24}>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        {/* Status Bar */}
+        <View style={styles.statusBar}>
+          <Text style={styles.statusText}>9:41</Text>
+          <View style={styles.statusIcons}>
+            <Text style={styles.statusDots}>••••</Text>
+            <Text style={styles.statusText}>📶</Text>
+            <Text style={styles.statusText}>🔋</Text>
+          </View>
+        </View>
 
-            <div className="flex-1 relative">
-              <video
-                ref={videoRef}
-                autoPlay
-                playsInline
-                className="w-full h-full object-cover"
-              />
+        {/* Header */}
+        <View style={styles.header}>
+          <View style={styles.profile}>
+            <Image
+              source={{
+                uri: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E",
+              }}
+              style={styles.avatar}
+            />
+            <View style={styles.profileText}>
+              <Text style={styles.greeting}>Hello, John</Text>
+              <Text style={styles.date}>{formatDate(currentDate)}</Text>
+            </View>
+          </View>
+          <TouchableOpacity style={styles.searchButton}>
+            <Feather name="search" size={20} color="#4B5563" />
+          </TouchableOpacity>
+        </View>
 
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="w-64 h-80 border-2 border-white/50 rounded-2xl flex items-center justify-center">
-                  <p className="text-white/70 text-sm text-center px-4">
-                    Position yourself within the frame for best results
-                  </p>
-                </div>
-              </div>
-            </div>
+        {/* Daily Challenge Card */}
+        <View style={styles.challengeCard}>
+          <Text style={styles.challengeTitle}>CaptureFit challenge</Text>
+          <Text style={styles.challengeSubtitle}>
+            AI-powered progress tracking
+          </Text>
+        </View>
 
-            <div className="p-6 flex justify-center">
-              <button
-                onClick={capturePhoto}
-                className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-lg"
-                disabled={isAnalyzing}
+        {/* Week Calendar */}
+        <View style={styles.weekRow}>
+          {weekDays.map((day, i) => (
+            <View key={day} style={styles.dayItem}>
+              <Text style={styles.dayLabel}>{day}</Text>
+              <View
+                style={[
+                  styles.dayCircle,
+                  i === todayIndex && styles.dayCircleToday,
+                ]}
               >
-                <div className="w-16 h-16 bg-blue-500 rounded-full flex items-center justify-center">
-                  <Camera className="w-8 h-8 text-white" />
-                </div>
-              </button>
-            </div>
-
-            {isAnalyzing && (
-              <div className="absolute inset-0 bg-black/80 flex items-center justify-center">
-                <div className="text-center text-white">
-                  <div className="w-8 h-8 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-                  <p className="text-lg font-semibold">
-                    Analyzing your progress...
-                  </p>
-                  <p className="text-sm opacity-70">
-                    AI is processing your photo
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-
-        <canvas ref={canvasRef} style={{ display: "none" }} />
-        {capturedImage && (
-          <img src={capturedImage} alt="captured" className="hidden" />
-        )}
-
-        <div className="flex justify-between items-center px-6 pt-3 pb-2">
-          <div className="text-sm font-medium">9:41</div>
-          <div className="flex items-center gap-1">
-            <div className="flex gap-1">
-              <div className="w-1 h-1 bg-gray-900 rounded-full" />
-              <div className="w-1 h-1 bg-gray-900 rounded-full" />
-              <div className="w-1 h-1 bg-gray-900 rounded-full" />
-              <div className="w-1 h-1 bg-gray-400 rounded-full" />
-            </div>
-            <div className="ml-2 text-sm">📶</div>
-            <div className="text-sm">🔋</div>
-          </div>
-        </div>
-
-        <div className="flex justify-between items-start px-6 pt-4 pb-6">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 rounded-full overflow-hidden">
-              <img
-                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23E5E7EB'/%3E%3Ctext x='24' y='30' text-anchor='middle' fill='%236B7280' font-family='Arial, sans-serif' font-size='16' font-weight='bold'%3EJ%3C/text%3E%3C/svg%3E"
-                alt="Profile"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <div>
-              <p className="text-gray-600 text-sm">Hello, John</p>
-              <p className="text-gray-900 font-medium">
-                {formatDate(currentDate)}
-              </p>
-            </div>
-          </div>
-          <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm">
-            <Search className="w-5 h-5 text-gray-600" />
-          </button>
-        </div>
-
-        <div className="px-6 mb-6">
-          <div className="bg-gradient-to-br from-blue-400 via-blue-500 to-green-500 rounded-3xl p-6 relative overflow-hidden">
-            <div className="absolute top-4 right-4 w-16 h-16 opacity-30">
-              <div className="w-8 h-8 bg-yellow-400 rounded-full absolute top-0 right-0" />
-              <div className="w-10 h-10 bg-orange-500 rounded-lg absolute bottom-0 left-0 transform rotate-12" />
-              <div className="w-6 h-6 bg-green-500 rounded-full absolute top-3 left-2" />
-            </div>
-
-            <div className="relative z-10">
-              <h2 className="text-white text-2xl font-bold mb-1">CaptureFit</h2>
-              <h2 className="text-white text-2xl font-bold mb-2">challenge</h2>
-              <p className="text-blue-100 text-sm mb-4">
-                Track your visual progress journey
-              </p>
-
-              <div className="flex -space-x-2 mb-4">
-                <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center text-xs font-bold text-blue-600">
-                  J
-                </div>
-                <div className="w-8 h-8 bg-yellow-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
-                  M
-                </div>
-                <div className="w-8 h-8 bg-green-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
-                  S
-                </div>
-                <div className="w-8 h-8 bg-pink-400 rounded-full flex items-center justify-center text-xs font-bold text-white">
-                  A
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="px-6 mb-6">
-          <div className="flex justify-between items-center">
-            {weekDays.map((day, index) => {
-              const dayNumber = 22 + index;
-              const isToday = index === today;
-              return (
-                <div key={day} className="text-center">
-                  <p className="text-gray-500 text-xs mb-2">{day}</p>
-                  <div
-                    className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-medium ${
-                      isToday
-                        ? "bg-gray-900 text-white"
-                        : "bg-white text-gray-600 border border-gray-200"
-                    }`}
-                  >
-                    {dayNumber}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className="px-6 mb-6">
-          <h3 className="text-gray-900 text-lg font-semibold mb-4">
-            Your progress
-          </h3>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div className="bg-gradient-to-br from-orange-200 to-orange-300 rounded-3xl p-5 relative overflow-hidden">
-              <div className="absolute -top-2 -right-2 w-12 h-12 bg-white/20 rounded-full" />
-              <div className="relative z-10">
-                <div className="mb-3">
-                  <Camera className="w-6 h-6 text-orange-800 mb-2" />
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    CaptureFit
-                  </h4>
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    Analysis
-                  </h4>
-                </div>
-                <p className="text-orange-800 text-xs mb-3">
-                  Visual progress tracking
-                </p>
-                <p className="text-orange-900 text-xs">📸 Ready to capture</p>
-              </div>
-            </div>
-
-            <div className="bg-gradient-to-br from-blue-100 to-blue-200 rounded-3xl p-5 relative overflow-hidden">
-              <div className="absolute -bottom-2 -right-2 w-16 h-16 bg-white/20 rounded-full" />
-              <div className="relative z-10">
-                <div className="mb-3">
-                  <TrendingUp className="w-6 h-6 text-blue-800 mb-2" />
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    Progress
-                  </h4>
-                  <h4 className="text-gray-900 font-semibold text-base">
-                    Stats
-                  </h4>
-                </div>
-                <p className="text-blue-800 text-xs mb-3">2 week streak</p>
-                <p className="text-blue-900 text-xs">📊 View timeline</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="px-6 mb-6">
-          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-gray-900 font-semibold">
-                This Week’s Progress
-              </h3>
-              <button>
-                <MoreHorizontal className="w-5 h-5 text-gray-400" />
-              </button>
-            </div>
-
-            <div className="grid grid-cols-3 gap-4">
-              <div className="text-center">
-                <div className="w-12 h-12 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
-                  <span className="text-lg">📸</span>
-                </div>
-                <p className="text-gray-900 font-semibold text-lg">2</p>
-                <p className="text-gray-500 text-xs">Photos taken</p>
-              </div>
-
-              <div className="text-center">
-                <div className="w-12 h-12 bg-blue-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
-                  <span className="text-lg">🔥</span>
-                </div>
-                <p className="text-gray-900 font-semibold text-lg">2</p>
-                <p className="text-gray-500 text-xs">Week streak</p>
-              </div>
-
-              <div className="text-center">
-                <div className="w-12 h-12 bg-orange-100 rounded-2xl flex items-center justify-center mx-auto mb-2">
-                  <span className="text-lg">📅</span>
-                </div>
-                <p className="text-gray-900 font-semibold text-lg">14</p>
-                <p className="text-gray-500 text-xs">Days tracked</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="px-6 mb-6">
-          <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100">
-            <h3 className="text-gray-900 font-semibold mb-4">
-              Visual Comparison
-            </h3>
-
-            <div className="flex gap-4">
-              <div className="flex-1">
-                <div className="aspect-[3/4] bg-gray-100 rounded-2xl flex items-center justify-center mb-3 relative overflow-hidden">
-                  <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-green-50"></div>
-                  <div className="relative z-10 text-center">
-                    <Calendar className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-                    <p className="text-gray-500 text-sm font-medium">
-                      Last week
-                    </p>
-                  </div>
-                </div>
-                <p className="text-center text-gray-600 text-sm font-medium">
-                  Before
-                </p>
-              </div>
-
-              <div className="flex items-center px-2">
-                <div className="w-8 h-0.5 bg-gray-200 rounded-full"></div>
-              </div>
-
-              <div className="flex-1">
-                <div
-                  className="aspect-[3/4] bg-gray-50 rounded-2xl flex items-center justify-center mb-3 border-2 border-dashed border-gray-200 relative overflow-hidden cursor-pointer"
-                  onClick={handleCameraClick}
+                <Text
+                  style={[
+                    styles.dayNumber,
+                    i === todayIndex && styles.dayNumberToday,
+                  ]}
                 >
-                  <div className="absolute inset-0 bg-gradient-to-br from-green-50 to-blue-50"></div>
-                  <div className="relative z-10 text-center">
-                    <Plus className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-                    <p className="text-gray-500 text-sm font-medium">
-                      This week
-                    </p>
-                  </div>
-                </div>
-                <p className="text-center text-gray-600 text-sm font-medium">
-                  This Week
-                </p>
-              </div>
-            </div>
+                  {baseDay + i}
+                </Text>
+              </View>
+            </View>
+          ))}
+        </View>
 
-            <button
-              onClick={handleCameraClick}
-              className="w-full bg-gray-900 text-white rounded-2xl py-4 flex items-center justify-center gap-2 mt-4 font-medium hover:bg-gray-800 transition-colors"
-              disabled={isAnalyzing}
-            >
-              <Camera className="w-5 h-5" />
-              <span>
-                {isAnalyzing ? "Analyzing..." : "Capture with CaptureFit"}
-              </span>
-            </button>
-          </div>
-        </div>
+        {/* Progress Section */}
+        <Text style={styles.sectionHeader}>Your progress</Text>
+        <View style={styles.progressRow}>
+          <View style={[styles.progressCard, { marginRight: 12 }]}>
+            <Feather name="camera" size={24} color="#9A3412" />
+            <Text style={styles.progressTitle}>CaptureFit Analysis</Text>
+            <Text style={styles.progressText}>AI body tracking</Text>
+          </View>
+          <View style={styles.progressCard}>
+            <Feather name="trending-up" size={24} color="#1E3A8A" />
+            <Text style={styles.progressTitle}>Progress Stats</Text>
+            <Text style={styles.progressText}>12 day streak</Text>
+          </View>
+        </View>
 
-        <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm">
-          <div className="bg-gray-900 mx-4 mb-6 rounded-3xl px-6 py-4">
-            <div className="flex justify-around items-center">
-              <button className="w-10 h-10 bg-white rounded-full flex items-center justify-center">
-                <div className="w-6 h-6 bg-gray-900 rounded-lg"></div>
-              </button>
-              <button className="p-2">
-                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex items-center justify-center">
-                  <div className="w-2 h-2 bg-gray-400 rounded-sm"></div>
-                </div>
-              </button>
-              <button className="p-2">
-                <div className="w-6 h-6 border-2 border-gray-400 rounded-lg flex flex-col gap-0.5 p-1">
-                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
-                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
-                  <div className="flex-1 bg-gray-400 rounded-xs"></div>
-                </div>
-              </button>
-              <button className="p-2">
-                <div className="w-6 h-6 bg-gray-400 rounded-full"></div>
-              </button>
-            </div>
-          </div>
-        </div>
+        {/* Today's Metrics */}
+        <Text style={styles.sectionHeader}>Today&apos;s Progress</Text>
+        <View style={styles.metricsRow}>
+          <View style={styles.metricItem}>
+            <Text style={styles.metricEmoji}>💪</Text>
+            <Text style={styles.metricValue}>+8%</Text>
+            <Text style={styles.metricLabel}>Muscle def.</Text>
+          </View>
+          <View style={styles.metricItem}>
+            <Text style={styles.metricEmoji}>🔥</Text>
+            <Text style={styles.metricValue}>-2.1%</Text>
+            <Text style={styles.metricLabel}>Body fat</Text>
+          </View>
+          <View style={styles.metricItem}>
+            <Text style={styles.metricEmoji}>📏</Text>
+            <Text style={styles.metricValue}>89</Text>
+            <Text style={styles.metricLabel}>Total pics</Text>
+          </View>
+        </View>
 
-        <div className="h-24"></div>
-      </div>
-    </div>
+        {/* Photo Comparison */}
+        <Text style={styles.sectionHeader}>Photo Comparison</Text>
+        <View style={styles.comparisonRow}>
+          <View style={styles.compareBox}>
+            <Feather name="calendar" size={32} color="#9CA3AF" />
+            <Text style={styles.compareLabel}>7 days ago</Text>
+          </View>
+          <View style={styles.compareSpacer} />
+          <View style={styles.compareBox}>
+            <Feather name="plus" size={32} color="#9CA3AF" />
+            <Text style={styles.compareLabel}>Take photo</Text>
+          </View>
+        </View>
+        <TouchableOpacity style={styles.captureButton}>
+          <Feather name="camera" size={20} color="#FFFFFF" />
+          <Text style={styles.captureText}>Capture with CaptureFit</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </Layout>
   );
-};
+}
 
-export default PhotoProgressApp;
+const styles = StyleSheet.create({
+  statusBar: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 16,
+  },
+  statusText: {
+    fontSize: 14,
+    color: "#111827",
+  },
+  statusIcons: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  statusDots: {
+    fontSize: 10,
+    color: "#111827",
+    marginRight: 8,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  profile: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    marginRight: 12,
+  },
+  profileText: {
+    justifyContent: "center",
+  },
+  greeting: {
+    color: "#4B5563",
+    fontSize: 14,
+  },
+  date: {
+    color: "#111827",
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  searchButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#FFFFFF",
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 1,
+  },
+  challengeCard: {
+    backgroundColor: "#60A5FA",
+    borderRadius: 24,
+    padding: 24,
+    marginBottom: 24,
+  },
+  challengeTitle: {
+    color: "#FFFFFF",
+    fontSize: 22,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  challengeSubtitle: {
+    color: "#DBEAFE",
+    fontSize: 14,
+  },
+  weekRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 24,
+  },
+  dayItem: {
+    alignItems: "center",
+  },
+  dayLabel: {
+    color: "#6B7280",
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  dayCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  dayCircleToday: {
+    backgroundColor: "#111827",
+    borderColor: "#111827",
+  },
+  dayNumber: {
+    color: "#4B5563",
+  },
+  dayNumberToday: {
+    color: "#FFFFFF",
+  },
+  sectionHeader: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#111827",
+    marginBottom: 16,
+  },
+  progressRow: {
+    flexDirection: "row",
+    marginBottom: 24,
+  },
+  progressCard: {
+    flex: 1,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 24,
+    padding: 16,
+  },
+  progressTitle: {
+    marginTop: 8,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  progressText: {
+    color: "#6B7280",
+    fontSize: 12,
+    marginTop: 4,
+  },
+  metricsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 24,
+  },
+  metricItem: {
+    flex: 1,
+    alignItems: "center",
+  },
+  metricEmoji: {
+    fontSize: 24,
+    marginBottom: 8,
+  },
+  metricValue: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  metricLabel: {
+    fontSize: 12,
+    color: "#6B7280",
+  },
+  comparisonRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  compareBox: {
+    flex: 1,
+    height: 200,
+    borderRadius: 16,
+    backgroundColor: "#F9FAFB",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  compareSpacer: {
+    width: 16,
+  },
+  compareLabel: {
+    color: "#6B7280",
+    marginTop: 8,
+  },
+  captureButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    paddingVertical: 12,
+  },
+  captureText: {
+    color: "#FFFFFF",
+    fontWeight: "500",
+    marginLeft: 8,
+  },
+});

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import { Camera as ExpoCamera } from "expo-camera";
 import { Feather } from "@expo/vector-icons";
-import Layout from "@/components/Layout";
+import { Layout } from "@/components/Layout";
 
 const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Camera as ExpoCamera, CameraType } from "expo-camera";
+import { Camera as ExpoCamera } from "expo-camera";
 import { Feather } from "@expo/vector-icons";
 import Layout from "@/components/Layout";
 
@@ -211,7 +211,7 @@ export default function PhotoProgressApp() {
           <ExpoCamera
             ref={cameraRef}
             style={StyleSheet.absoluteFill}
-            type={CameraType.front}
+            type="front"
           />
           <View style={styles.cameraHeader}>
             <TouchableOpacity onPress={stopCamera}>
@@ -691,4 +691,3 @@ const styles = StyleSheet.create({
     marginLeft: 8,
   },
 });
-

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,8 +1,15 @@
 import React, { useContext } from "react";
-import ProgressScreen from "@/components/ProgressScreen";
+import CameraScreen from "@/components/CameraScreen";
 import { PhotoContext } from "./_layout";
 
 export default function ProgressPage() {
-  const { photos, setPhotos } = useContext(PhotoContext);
-  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
+  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
+  return (
+    <CameraScreen
+      photos={photos}
+      setPhotos={setPhotos}
+      loading={loading}
+      setLoading={setLoading}
+    />
+  );
 }

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,8 +1,15 @@
 import React, { useContext } from 'react';
-import ProgressScreen from '@/components/ProgressScreen';
+import CameraScreen from '@/components/CameraScreen';
 import { PhotoContext } from './_layout';
 
 export default function ProgressPage() {
-  const { photos, setPhotos } = useContext(PhotoContext);
-  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
+  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
+  return (
+    <CameraScreen
+      photos={photos}
+      setPhotos={setPhotos}
+      loading={loading}
+      setLoading={setLoading}
+    />
+  );
 }

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,15 +1,8 @@
-import React, { useContext } from 'react';
-import CameraScreen from '@/components/CameraScreen';
-import { PhotoContext } from './_layout';
+import React, { useContext } from "react";
+import ProgressScreen from "@/components/ProgressScreen";
+import { PhotoContext } from "./_layout";
 
 export default function ProgressPage() {
-  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
-  return (
-    <CameraScreen
-      photos={photos}
-      setPhotos={setPhotos}
-      loading={loading}
-      setLoading={setLoading}
-    />
-  );
+  const { photos, setPhotos } = useContext(PhotoContext);
+  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
 }

--- a/components/CameraScreen.js
+++ b/components/CameraScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -9,22 +9,27 @@ import {
   StatusBar,
   ScrollView,
   Dimensions,
-} from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Camera } from 'expo-camera';
-import * as FileSystem from 'expo-file-system';
-import * as ImagePicker from 'expo-image-picker';
-import { Feather } from '@expo/vector-icons';
-import { LinearGradient } from 'expo-linear-gradient';
+} from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Camera } from "expo-camera";
+import * as FileSystem from "expo-file-system";
+import * as ImagePicker from "expo-image-picker";
+import { Feather } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
 
-const { width: screenWidth } = Dimensions.get('window');
-const OPENAI_API_KEY = 'your-api-key-here'; // Replace with your actual key
+const { width: screenWidth } = Dimensions.get("window");
+const OPENAI_API_KEY = "your-api-key-here"; // Replace with your actual key
 
 // Modern Fitness Home Screen Component
-export default function CameraScreen({ photos, setPhotos, loading, setLoading }) {
+export default function CameraScreen({
+  photos,
+  setPhotos,
+  loading,
+  setLoading,
+}) {
   const [cameraPermission, setCameraPermission] = useState(null);
   const [showWelcome, setShowWelcome] = useState(true);
-  const [currentDate, setCurrentDate] = useState(new Date());
+  const [currentDate] = useState(new Date());
 
   useEffect(() => {
     getCameraPermission();
@@ -33,32 +38,32 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
 
   const checkWelcomeStatus = async () => {
     try {
-      const hasSeenWelcome = await AsyncStorage.getItem('hasSeenWelcome');
-      if (hasSeenWelcome === 'true') {
+      const hasSeenWelcome = await AsyncStorage.getItem("hasSeenWelcome");
+      if (hasSeenWelcome === "true") {
         setShowWelcome(false);
       }
     } catch (error) {
-      console.error('Error checking welcome status:', error);
+      console.error("Error checking welcome status:", error);
     }
   };
 
   const handleGetStarted = async () => {
     try {
-      await AsyncStorage.setItem('hasSeenWelcome', 'true');
+      await AsyncStorage.setItem("hasSeenWelcome", "true");
       setShowWelcome(false);
     } catch (error) {
-      console.error('Error saving welcome status:', error);
+      console.error("Error saving welcome status:", error);
     }
   };
 
   const getCameraPermission = async () => {
     const { status } = await Camera.requestCameraPermissionsAsync();
-    setCameraPermission(status === 'granted');
+    setCameraPermission(status === "granted");
   };
 
   const takePhoto = async () => {
     if (!cameraPermission) {
-      Alert.alert('Camera permission required');
+      Alert.alert("Camera permission required");
       return;
     }
 
@@ -92,21 +97,23 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
         analysis: null,
       };
 
-      const previousPhoto = photos.length > 0 ? photos[photos.length - 1] : null;
+      const previousPhoto =
+        photos.length > 0 ? photos[photos.length - 1] : null;
 
       if (previousPhoto) {
         const analysis = await getAIAnalysis(previousPhoto.uri, permanentUri);
         newPhoto.analysis = analysis;
       } else {
-        newPhoto.analysis = "Great start! This is your first progress photo. Keep going!";
+        newPhoto.analysis =
+          "Great start! This is your first progress photo. Keep going!";
       }
 
       const updatedPhotos = [...photos, newPhoto];
       await savePhotos(updatedPhotos);
       setPhotos(updatedPhotos);
     } catch (error) {
-      console.error('Error processing photo:', error);
-      Alert.alert('Error', 'Failed to save photo. Please try again.');
+      console.error("Error processing photo:", error);
+      Alert.alert("Error", "Failed to save photo. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -114,44 +121,57 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
 
   const getAIAnalysis = async (previousPhotoUri, currentPhotoUri) => {
     try {
-      const userGoal = await AsyncStorage.getItem('fitnessGoal') || '';
+      const userGoal = (await AsyncStorage.getItem("fitnessGoal")) || "";
       const previousBase64 = await uriToBase64(previousPhotoUri);
       const currentBase64 = await uriToBase64(currentPhotoUri);
 
-      let goalContext = '';
+      let goalContext = "";
       if (userGoal) {
         goalContext = `The user's fitness goal is: "${userGoal}". `;
       }
 
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${OPENAI_API_KEY}`,
+      const response = await fetch(
+        "https://api.openai.com/v1/chat/completions",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${OPENAI_API_KEY}`,
+          },
+          body: JSON.stringify({
+            model: "gpt-4o",
+            messages: [
+              {
+                role: "user",
+                content: [
+                  {
+                    type: "text",
+                    text: `${goalContext}Compare these progress photos and provide encouraging feedback.`,
+                  },
+                  {
+                    type: "image_url",
+                    image_url: {
+                      url: `data:image/jpeg;base64,${previousBase64}`,
+                    },
+                  },
+                  {
+                    type: "image_url",
+                    image_url: {
+                      url: `data:image/jpeg;base64,${currentBase64}`,
+                    },
+                  },
+                ],
+              },
+            ],
+            max_tokens: 200,
+          }),
         },
-        body: JSON.stringify({
-          model: 'gpt-4o',
-          messages: [
-            {
-              role: 'user',
-              content: [
-                {
-                  type: 'text',
-                  text: `${goalContext}Compare these progress photos and provide encouraging feedback.`,
-                },
-                { type: 'image_url', image_url: { url: `data:image/jpeg;base64,${previousBase64}` } },
-                { type: 'image_url', image_url: { url: `data:image/jpeg;base64,${currentBase64}` } },
-              ],
-            },
-          ],
-          max_tokens: 200,
-        }),
-      });
+      );
 
       const data = await response.json();
       return data.choices[0].message.content;
     } catch (error) {
-      console.error('AI Analysis Error:', error);
+      console.error("AI Analysis Error:", error);
       return "Progress photo saved! Keep up the great work!";
     }
   };
@@ -163,29 +183,29 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
       });
       return base64;
     } catch (error) {
-      console.error('Error converting to base64:', error);
+      console.error("Error converting to base64:", error);
       return null;
     }
   };
 
   const savePhotos = async (newPhotos) => {
     try {
-      await AsyncStorage.setItem('progressPhotos', JSON.stringify(newPhotos));
+      await AsyncStorage.setItem("progressPhotos", JSON.stringify(newPhotos));
     } catch (error) {
-      console.error('Error saving photos:', error);
+      console.error("Error saving photos:", error);
     }
   };
 
   // Generate week days for calendar
   const generateWeekDays = () => {
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
     const today = new Date();
     const currentDay = today.getDay();
-    
+
     return days.map((day, index) => {
       const date = new Date(today);
       date.setDate(today.getDate() - currentDay + index);
-      
+
       return {
         day,
         date: date.getDate(),
@@ -213,9 +233,12 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
           </View>
         </View>
         <View style={styles.welcomeContent}>
-          <Text style={styles.welcomeTitle}>Track Your Fitness{'\n'}Journey</Text>
+          <Text style={styles.welcomeTitle}>
+            Track Your Fitness{"\n"}Journey
+          </Text>
           <Text style={styles.welcomeSubtitle}>
-            Capture progress photos and get AI-powered insights to achieve your fitness goals.
+            Capture progress photos and get AI-powered insights to achieve your
+            fitness goals.
           </Text>
           <View style={styles.pageIndicators}>
             <View style={[styles.indicator, styles.indicatorActive]} />
@@ -239,18 +262,26 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
   return (
     <View style={styles.container}>
       <StatusBar barStyle="dark-content" backgroundColor="white" />
-      
+
       {/* Header */}
       <View style={styles.header}>
         <View style={styles.headerContent}>
           <View style={styles.userProfile}>
             <Image
-              source={{ uri: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop' }}
+              source={{
+                uri: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop",
+              }}
               style={styles.profileImage}
             />
             <View style={styles.greetingContainer}>
               <Text style={styles.greeting}>Hello, User</Text>
-              <Text style={styles.date}>Today {currentDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short' })}</Text>
+              <Text style={styles.date}>
+                Today{" "}
+                {currentDate.toLocaleDateString("en-US", {
+                  day: "numeric",
+                  month: "short",
+                })}
+              </Text>
             </View>
           </View>
           <TouchableOpacity style={styles.searchButton}>
@@ -259,31 +290,57 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
         </View>
       </View>
 
-      <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={styles.scrollView}
+        showsVerticalScrollIndicator={false}
+      >
         {/* Daily Challenge Card */}
         <View style={styles.challengeCard}>
           <LinearGradient
-            colors={['#8B5FBF', '#6A4C93']}
+            colors={["#8B5FBF", "#6A4C93"]}
             style={styles.challengeGradient}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
           >
             <View style={styles.challengeContent}>
-              <Text style={styles.challengeTitle}>Daily{'\n'}challenge</Text>
-              <Text style={styles.challengeSubtitle}>Do your plan before 09:00 AM</Text>
-              
+              <Text style={styles.challengeTitle}>Daily{"\n"}challenge</Text>
+              <Text style={styles.challengeSubtitle}>
+                Do your plan before 09:00 AM
+              </Text>
+
               <View style={styles.challengeAvatars}>
                 <View style={styles.avatarGroup}>
-                  <Image source={{ uri: 'https://images.unsplash.com/photo-1494790108755-2616b5c3f95c?w=50&h=50&fit=crop' }} style={[styles.avatar, { zIndex: 3 }]} />
-                  <Image source={{ uri: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=50&h=50&fit=crop' }} style={[styles.avatar, { marginLeft: -10, zIndex: 2 }]} />
-                  <Image source={{ uri: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=50&h=50&fit=crop' }} style={[styles.avatar, { marginLeft: -10, zIndex: 1 }]} />
-                  <View style={[styles.avatar, styles.moreAvatar, { marginLeft: -10 }]}>
+                  <Image
+                    source={{
+                      uri: "https://images.unsplash.com/photo-1494790108755-2616b5c3f95c?w=50&h=50&fit=crop",
+                    }}
+                    style={[styles.avatar, { zIndex: 3 }]}
+                  />
+                  <Image
+                    source={{
+                      uri: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=50&h=50&fit=crop",
+                    }}
+                    style={[styles.avatar, { marginLeft: -10, zIndex: 2 }]}
+                  />
+                  <Image
+                    source={{
+                      uri: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=50&h=50&fit=crop",
+                    }}
+                    style={[styles.avatar, { marginLeft: -10, zIndex: 1 }]}
+                  />
+                  <View
+                    style={[
+                      styles.avatar,
+                      styles.moreAvatar,
+                      { marginLeft: -10 },
+                    ]}
+                  >
                     <Text style={styles.moreAvatarText}>+</Text>
                   </View>
                 </View>
               </View>
             </View>
-            
+
             <View style={styles.challengeDecorations}>
               <View style={styles.dumbbell} />
               <View style={styles.kettlebell} />
@@ -298,19 +355,23 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
               key={index}
               style={[
                 styles.dayButton,
-                dayInfo.isToday && styles.dayButtonActive
+                dayInfo.isToday && styles.dayButtonActive,
               ]}
             >
-              <Text style={[
-                styles.dayText,
-                dayInfo.isToday && styles.dayTextActive
-              ]}>
+              <Text
+                style={[
+                  styles.dayText,
+                  dayInfo.isToday && styles.dayTextActive,
+                ]}
+              >
                 {dayInfo.day}
               </Text>
-              <Text style={[
-                styles.dateText,
-                dayInfo.isToday && styles.dateTextActive
-              ]}>
+              <Text
+                style={[
+                  styles.dateText,
+                  dayInfo.isToday && styles.dateTextActive,
+                ]}
+              >
                 {dayInfo.date}
               </Text>
             </TouchableOpacity>
@@ -324,25 +385,37 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
 
         <View style={styles.planGrid}>
           {/* Progress Photos Card */}
-          <TouchableOpacity style={[styles.planCard, styles.progressCard]} onPress={takePhoto}>
+          <TouchableOpacity
+            style={[styles.planCard, styles.progressCard]}
+            onPress={takePhoto}
+          >
             <LinearGradient
-              colors={['#FF9A56', '#FF6B35']}
+              colors={["#FF9A56", "#FF6B35"]}
               style={styles.planCardGradient}
             >
               <View style={styles.planCardContent}>
-                <Text style={styles.planCardTitle}>Progress{'\n'}Photos</Text>
-                <Text style={styles.planCardDate}>{new Date().toLocaleDateString('en-US', { day: 'numeric', month: 'short' })}</Text>
+                <Text style={styles.planCardTitle}>Progress{"\n"}Photos</Text>
+                <Text style={styles.planCardDate}>
+                  {new Date().toLocaleDateString("en-US", {
+                    day: "numeric",
+                    month: "short",
+                  })}
+                </Text>
                 <Text style={styles.planCardTime}>Take Photo</Text>
                 <Text style={styles.planCardLocation}>AI Analysis</Text>
-                
+
                 <View style={styles.planCardTrainer}>
                   <Feather name="camera" size={16} color="#FF9A56" />
                   <Text style={styles.trainerName}>AI Coach</Text>
                 </View>
               </View>
-              
+
               <View style={styles.planCardIcon}>
-                <Feather name="camera" size={24} color="rgba(255,255,255,0.8)" />
+                <Feather
+                  name="camera"
+                  size={24}
+                  color="rgba(255,255,255,0.8)"
+                />
               </View>
             </LinearGradient>
           </TouchableOpacity>
@@ -350,23 +423,32 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
           {/* View Progress Card */}
           <TouchableOpacity style={[styles.planCard, styles.balanceCard]}>
             <LinearGradient
-              colors={['#A8E6CF', '#7FCDCD']}
+              colors={["#A8E6CF", "#7FCDCD"]}
               style={styles.planCardGradient}
             >
               <View style={styles.planCardContent}>
-                <Text style={styles.planCardTitle}>View{'\n'}Progress</Text>
-                <Text style={styles.planCardDate}>{new Date().toLocaleDateString('en-US', { day: 'numeric', month: 'short' })}</Text>
+                <Text style={styles.planCardTitle}>View{"\n"}Progress</Text>
+                <Text style={styles.planCardDate}>
+                  {new Date().toLocaleDateString("en-US", {
+                    day: "numeric",
+                    month: "short",
+                  })}
+                </Text>
                 <Text style={styles.planCardTime}>{photos.length} photos</Text>
                 <Text style={styles.planCardLocation}>Gallery</Text>
-                
+
                 <View style={styles.planCardTrainer}>
                   <Feather name="trending-up" size={16} color="#A8E6CF" />
                   <Text style={styles.trainerName}>Progress</Text>
                 </View>
               </View>
-              
+
               <View style={styles.planCardIcon}>
-                <Feather name="bar-chart-2" size={24} color="rgba(255,255,255,0.8)" />
+                <Feather
+                  name="bar-chart-2"
+                  size={24}
+                  color="rgba(255,255,255,0.8)"
+                />
               </View>
             </LinearGradient>
           </TouchableOpacity>
@@ -382,9 +464,13 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
                 style={styles.recentPhotoImage}
               />
               <View style={styles.recentPhotoContent}>
-                <Text style={styles.recentPhotoTitle}>Latest Progress Photo</Text>
+                <Text style={styles.recentPhotoTitle}>
+                  Latest Progress Photo
+                </Text>
                 <Text style={styles.recentPhotoDate}>
-                  {new Date(photos[photos.length - 1].timestamp).toLocaleDateString()}
+                  {new Date(
+                    photos[photos.length - 1].timestamp,
+                  ).toLocaleDateString()}
                 </Text>
                 {photos[photos.length - 1].analysis && (
                   <Text style={styles.recentPhotoAnalysis} numberOfLines={2}>
@@ -415,127 +501,121 @@ const styles = {
   // Welcome Screen Styles
   welcomeContainer: {
     flex: 1,
-    backgroundColor: 'white',
+    backgroundColor: "white",
     paddingTop: 50,
   },
   skipButton: {
-    position: 'absolute',
+    position: "absolute",
     top: 60,
     right: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     zIndex: 10,
   },
   skipText: {
     fontSize: 16,
-    color: '#666',
+    color: "#666",
     marginRight: 4,
   },
   skipArrow: {
     fontSize: 18,
-    color: '#666',
-    fontWeight: 'bold',
+    color: "#666",
+    fontWeight: "bold",
   },
   heroImageContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     paddingHorizontal: 40,
     paddingTop: 40,
   },
   heroImageBackground: {
     width: 280,
     height: 280,
-    backgroundColor: '#a8e6cf',
+    backgroundColor: "#a8e6cf",
     borderRadius: 40,
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 10 },
-    shadowOpacity: 0.1,
-    shadowRadius: 20,
+    justifyContent: "center",
+    alignItems: "center",
+    boxShadow: "0px 10px 20px rgba(0,0,0,0.1)",
     elevation: 10,
   },
   heroImageText: {
     fontSize: 18,
-    fontWeight: '600',
-    color: '#333',
+    fontWeight: "600",
+    color: "#333",
     marginTop: 10,
   },
   welcomeContent: {
     paddingHorizontal: 30,
     paddingBottom: 50,
-    alignItems: 'center',
+    alignItems: "center",
   },
   welcomeTitle: {
     fontSize: 32,
-    fontWeight: 'bold',
-    color: '#000',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "#000",
+    textAlign: "center",
     lineHeight: 38,
     marginBottom: 16,
   },
   welcomeSubtitle: {
     fontSize: 16,
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
     lineHeight: 24,
     marginBottom: 40,
     paddingHorizontal: 10,
   },
   pageIndicators: {
-    flexDirection: 'row',
+    flexDirection: "row",
     marginBottom: 40,
   },
   indicator: {
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#e0e0e0',
+    backgroundColor: "#e0e0e0",
     marginHorizontal: 4,
   },
   indicatorActive: {
-    backgroundColor: '#a8e6cf',
+    backgroundColor: "#a8e6cf",
     width: 24,
   },
   getStartedButton: {
-    backgroundColor: '#a8e6cf',
+    backgroundColor: "#a8e6cf",
     paddingVertical: 18,
     paddingHorizontal: 80,
     borderRadius: 30,
-    width: '100%',
-    alignItems: 'center',
-    shadowColor: '#a8e6cf',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
+    width: "100%",
+    alignItems: "center",
+    boxShadow: "0px 4px 8px rgba(168,230,207,0.3)",
     elevation: 8,
   },
   getStartedText: {
     fontSize: 18,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
   },
 
   // Main App Styles
   container: {
     flex: 1,
-    backgroundColor: '#FAFAFA',
+    backgroundColor: "#FAFAFA",
   },
   header: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     paddingTop: 50,
     paddingHorizontal: 20,
     paddingBottom: 20,
   },
   headerContent: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   userProfile: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
   },
   profileImage: {
     width: 50,
@@ -548,21 +628,21 @@ const styles = {
   },
   greeting: {
     fontSize: 18,
-    fontWeight: '600',
-    color: '#000',
+    fontWeight: "600",
+    color: "#000",
   },
   date: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginTop: 2,
   },
   searchButton: {
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#F5F5F5',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#F5F5F5",
+    justifyContent: "center",
+    alignItems: "center",
   },
   scrollView: {
     flex: 1,
@@ -572,87 +652,81 @@ const styles = {
     marginTop: 20,
     marginBottom: 20,
     borderRadius: 20,
-    overflow: 'hidden',
-    shadowColor: '#8B5FBF',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.3,
-    shadowRadius: 20,
+    overflow: "hidden",
+    boxShadow: "0px 8px 20px rgba(139,95,191,0.3)",
     elevation: 10,
   },
   challengeGradient: {
     padding: 20,
     minHeight: 140,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    justifyContent: "space-between",
   },
   challengeContent: {
     flex: 1,
   },
   challengeTitle: {
     fontSize: 24,
-    fontWeight: 'bold',
-    color: 'white',
+    fontWeight: "bold",
+    color: "white",
     lineHeight: 28,
   },
   challengeSubtitle: {
     fontSize: 14,
-    color: 'rgba(255,255,255,0.8)',
+    color: "rgba(255,255,255,0.8)",
     marginTop: 8,
     marginBottom: 16,
   },
   challengeAvatars: {
-    marginTop: 'auto',
+    marginTop: "auto",
   },
   avatarGroup: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
   },
   avatar: {
     width: 30,
     height: 30,
     borderRadius: 15,
     borderWidth: 2,
-    borderColor: 'white',
+    borderColor: "white",
   },
   moreAvatar: {
-    backgroundColor: 'rgba(255,255,255,0.3)',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "rgba(255,255,255,0.3)",
+    justifyContent: "center",
+    alignItems: "center",
   },
   moreAvatarText: {
-    color: 'white',
+    color: "white",
     fontSize: 12,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
   challengeDecorations: {
-    position: 'absolute',
+    position: "absolute",
     right: 20,
     top: 20,
   },
   dumbbell: {
     width: 40,
     height: 40,
-    backgroundColor: 'rgba(255,255,255,0.2)',
+    backgroundColor: "rgba(255,255,255,0.2)",
     borderRadius: 20,
     marginBottom: 10,
   },
   kettlebell: {
     width: 35,
     height: 35,
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: "rgba(255,255,255,0.15)",
     borderRadius: 17,
   },
   calendarContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    backgroundColor: 'white',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    backgroundColor: "white",
     borderRadius: 15,
     padding: 8,
     marginBottom: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 10,
+    boxShadow: "0px 2px 10px rgba(0,0,0,0.05)",
     elevation: 3,
   },
   dayButton: {
@@ -660,100 +734,97 @@ const styles = {
     paddingVertical: 12,
     paddingHorizontal: 8,
     borderRadius: 10,
-    alignItems: 'center',
+    alignItems: "center",
   },
   dayButtonActive: {
-    backgroundColor: '#000',
+    backgroundColor: "#000",
   },
   dayText: {
     fontSize: 12,
-    color: '#666',
-    fontWeight: '500',
+    color: "#666",
+    fontWeight: "500",
   },
   dayTextActive: {
-    color: 'white',
+    color: "white",
   },
   dateText: {
     fontSize: 16,
-    color: '#000',
-    fontWeight: '600',
+    color: "#000",
+    fontWeight: "600",
     marginTop: 4,
   },
   dateTextActive: {
-    color: 'white',
+    color: "white",
   },
   sectionHeader: {
     marginBottom: 16,
   },
   sectionTitle: {
     fontSize: 20,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
   },
   planGrid: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    justifyContent: "space-between",
     marginBottom: 30,
   },
   planCard: {
     width: (screenWidth - 50) / 2,
     height: 180,
     borderRadius: 20,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.15,
-    shadowRadius: 20,
+    overflow: "hidden",
+    boxShadow: "0px 8px 20px rgba(0,0,0,0.15)",
     elevation: 8,
   },
   planCardGradient: {
     flex: 1,
     padding: 16,
-    justifyContent: 'space-between',
+    justifyContent: "space-between",
   },
   planCardContent: {
     flex: 1,
   },
   planCardTitle: {
     fontSize: 18,
-    fontWeight: 'bold',
-    color: 'white',
+    fontWeight: "bold",
+    color: "white",
     lineHeight: 22,
     marginBottom: 8,
   },
   planCardDate: {
     fontSize: 12,
-    color: 'rgba(255,255,255,0.8)',
+    color: "rgba(255,255,255,0.8)",
     marginBottom: 2,
   },
   planCardTime: {
     fontSize: 14,
-    color: 'rgba(255,255,255,0.9)',
-    fontWeight: '600',
+    color: "rgba(255,255,255,0.9)",
+    fontWeight: "600",
     marginBottom: 2,
   },
   planCardLocation: {
     fontSize: 12,
-    color: 'rgba(255,255,255,0.7)',
+    color: "rgba(255,255,255,0.7)",
     marginBottom: 12,
   },
   planCardTrainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: 'rgba(255,255,255,0.2)',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(255,255,255,0.2)",
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 12,
-    alignSelf: 'flex-start',
+    alignSelf: "flex-start",
   },
   trainerName: {
     fontSize: 12,
-    color: 'white',
+    color: "white",
     marginLeft: 4,
-    fontWeight: '500',
+    fontWeight: "500",
   },
   planCardIcon: {
-    position: 'absolute',
+    position: "absolute",
     top: 16,
     right: 16,
   },
@@ -761,16 +832,13 @@ const styles = {
     marginBottom: 30,
   },
   recentPhotoCard: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     borderRadius: 15,
     padding: 16,
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     marginTop: 12,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 10,
+    boxShadow: "0px 2px 10px rgba(0,0,0,0.05)",
     elevation: 3,
   },
   recentPhotoImage: {
@@ -784,46 +852,46 @@ const styles = {
   },
   recentPhotoTitle: {
     fontSize: 16,
-    fontWeight: '600',
-    color: '#000',
+    fontWeight: "600",
+    color: "#000",
     marginBottom: 4,
   },
   recentPhotoDate: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginBottom: 8,
   },
   recentPhotoAnalysis: {
     fontSize: 12,
-    color: '#999',
+    color: "#999",
     lineHeight: 16,
   },
   loadingOverlay: {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
   },
   loadingCard: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     borderRadius: 20,
     padding: 30,
-    alignItems: 'center',
+    alignItems: "center",
     margin: 40,
   },
   loadingTitle: {
     fontSize: 18,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
     marginTop: 16,
     marginBottom: 8,
   },
   loadingSubtext: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
   },
 };

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,39 +1,46 @@
-import React from 'react';
+import React from "react";
 import {
   View,
   SafeAreaView,
   StatusBar,
   Platform,
   StyleSheet,
-} from 'react-native';
+  TouchableOpacity,
+  Text,
+  ActivityIndicator,
+} from "react-native";
 
-const Layout = ({ 
-  children, 
-  backgroundColor = '#FAFAFA', 
-  statusBarStyle = 'dark-content',
-  statusBarBackgroundColor = 'white',
-  safeAreaBackground = 'white',
+const Layout = ({
+  children,
+  backgroundColor = "#FAFAFA",
+  statusBarStyle = "dark-content",
+  statusBarBackgroundColor = "white",
+  safeAreaBackground = "white",
   padding = 0,
   paddingHorizontal = 0,
   paddingVertical = 0,
 }) => {
   return (
     <>
-      <StatusBar 
+      <StatusBar
         barStyle={statusBarStyle}
         backgroundColor={statusBarBackgroundColor}
         translucent={false}
       />
-      <SafeAreaView style={[styles.safeArea, { backgroundColor: safeAreaBackground }]}>
-        <View style={[
-          styles.container, 
-          { 
-            backgroundColor,
-            padding,
-            paddingHorizontal,
-            paddingVertical,
-          }
-        ]}>
+      <SafeAreaView
+        style={[styles.safeArea, { backgroundColor: safeAreaBackground }]}
+      >
+        <View
+          style={[
+            styles.container,
+            {
+              backgroundColor,
+              padding,
+              paddingHorizontal,
+              paddingVertical,
+            },
+          ]}
+        >
           {children}
         </View>
       </SafeAreaView>
@@ -42,46 +49,46 @@ const Layout = ({
 };
 
 // Modern Header Component for consistent headers across screens
-export const ModernHeader = ({ 
-  title, 
-  subtitle, 
-  leftIcon, 
-  rightIcon, 
-  onLeftPress, 
+export const ModernHeader = ({
+  title,
+  subtitle,
+  leftIcon,
+  rightIcon,
+  onLeftPress,
   onRightPress,
-  backgroundColor = 'white',
+  backgroundColor = "white",
   showBorder = true,
 }) => {
   return (
-    <View style={[
-      styles.modernHeader, 
-      { backgroundColor },
-      showBorder && styles.modernHeaderBorder
-    ]}>
+    <View
+      style={[
+        styles.modernHeader,
+        { backgroundColor },
+        showBorder && styles.modernHeaderBorder,
+      ]}
+    >
       <View style={styles.headerContent}>
         {/* Left Icon/Button */}
         {leftIcon && (
-          <TouchableOpacity 
-            style={styles.headerButton} 
+          <TouchableOpacity
+            style={styles.headerButton}
             onPress={onLeftPress}
             activeOpacity={0.7}
           >
             {leftIcon}
           </TouchableOpacity>
         )}
-        
+
         {/* Title Section */}
         <View style={styles.headerTitleContainer}>
           <Text style={styles.headerTitle}>{title}</Text>
-          {subtitle && (
-            <Text style={styles.headerSubtitle}>{subtitle}</Text>
-          )}
+          {subtitle && <Text style={styles.headerSubtitle}>{subtitle}</Text>}
         </View>
-        
+
         {/* Right Icon/Button */}
         {rightIcon && (
-          <TouchableOpacity 
-            style={styles.headerButton} 
+          <TouchableOpacity
+            style={styles.headerButton}
             onPress={onRightPress}
             activeOpacity={0.7}
           >
@@ -94,16 +101,16 @@ export const ModernHeader = ({
 };
 
 // Modern Card Component for consistent card styling
-export const ModernCard = ({ 
-  children, 
-  style, 
+export const ModernCard = ({
+  children,
+  style,
   padding = 16,
   margin = 0,
   marginHorizontal = 0,
   marginVertical = 0,
-  backgroundColor = 'white',
+  backgroundColor = "white",
   borderRadius = 15,
-  shadowColor = '#000',
+  shadowColor = "#000",
   shadowOpacity = 0.05,
   elevation = 3,
   onPress,
@@ -126,56 +133,51 @@ export const ModernCard = ({
 
   if (onPress) {
     return (
-      <TouchableOpacity style={cardStyle} onPress={onPress} activeOpacity={0.95}>
+      <TouchableOpacity
+        style={cardStyle}
+        onPress={onPress}
+        activeOpacity={0.95}
+      >
         {children}
       </TouchableOpacity>
     );
   }
 
-  return (
-    <View style={cardStyle}>
-      {children}
-    </View>
-  );
+  return <View style={cardStyle}>{children}</View>;
 };
 
 // Section Header Component
-export const SectionHeader = ({ 
-  title, 
-  subtitle, 
+export const SectionHeader = ({
+  title,
+  subtitle,
   rightElement,
   marginBottom = 16,
   marginTop = 0,
 }) => {
   return (
-    <View style={[
-      styles.sectionHeader, 
-      { marginBottom, marginTop }
-    ]}>
+    <View style={[styles.sectionHeader, { marginBottom, marginTop }]}>
       <View style={styles.sectionTitleContainer}>
         <Text style={styles.sectionTitle}>{title}</Text>
-        {subtitle && (
-          <Text style={styles.sectionSubtitle}>{subtitle}</Text>
-        )}
+        {subtitle && <Text style={styles.sectionSubtitle}>{subtitle}</Text>}
       </View>
       {rightElement && (
-        <View style={styles.sectionRightElement}>
-          {rightElement}
-        </View>
+        <View style={styles.sectionRightElement}>{rightElement}</View>
       )}
     </View>
   );
 };
 
 // Loading Component
-export const ModernLoading = ({ 
-  title = "Loading...", 
+export const ModernLoading = ({
+  title = "Loading...",
   subtitle = "Please wait",
   color = "#8B5FBF",
   overlay = true,
 }) => {
-  const containerStyle = overlay ? styles.loadingOverlay : styles.loadingContainer;
-  
+  const containerStyle = overlay
+    ? styles.loadingOverlay
+    : styles.loadingContainer;
+
   return (
     <View style={containerStyle}>
       <View style={styles.loadingCard}>
@@ -188,11 +190,11 @@ export const ModernLoading = ({
 };
 
 // Empty State Component
-export const EmptyState = ({ 
-  icon, 
-  title, 
-  subtitle, 
-  buttonText, 
+export const EmptyState = ({
+  icon,
+  title,
+  subtitle,
+  buttonText,
   onButtonPress,
   iconSize = 60,
 }) => {
@@ -205,8 +207,8 @@ export const EmptyState = ({
         <Text style={styles.emptyStateTitle}>{title}</Text>
         <Text style={styles.emptyStateSubtitle}>{subtitle}</Text>
         {buttonText && onButtonPress && (
-          <TouchableOpacity 
-            style={styles.emptyStateButton} 
+          <TouchableOpacity
+            style={styles.emptyStateButton}
             onPress={onButtonPress}
             activeOpacity={0.8}
           >
@@ -225,48 +227,48 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  
+
   // Modern Header Styles
   modernHeader: {
-    paddingTop: Platform.OS === 'ios' ? 10 : 20,
+    paddingTop: Platform.OS === "ios" ? 10 : 20,
     paddingBottom: 20,
     paddingHorizontal: 20,
   },
   modernHeaderBorder: {
     borderBottomWidth: 1,
-    borderBottomColor: '#F0F0F0',
+    borderBottomColor: "#F0F0F0",
   },
   headerContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   headerButton: {
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#F5F5F5',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#F5F5F5",
+    justifyContent: "center",
+    alignItems: "center",
   },
   headerTitleContainer: {
     flex: 1,
-    alignItems: 'center',
+    alignItems: "center",
     paddingHorizontal: 20,
   },
   headerTitle: {
     fontSize: 18,
-    fontWeight: '600',
-    color: '#000',
-    textAlign: 'center',
+    fontWeight: "600",
+    color: "#000",
+    textAlign: "center",
   },
   headerSubtitle: {
     fontSize: 14,
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
     marginTop: 2,
   },
-  
+
   // Modern Card Styles
   modernCard: {
     shadowOffset: { width: 0, height: 2 },
@@ -274,54 +276,54 @@ const styles = StyleSheet.create({
     // Android shadow
     elevation: 3,
   },
-  
+
   // Section Header Styles
   sectionHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-end',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
   },
   sectionTitleContainer: {
     flex: 1,
   },
   sectionTitle: {
     fontSize: 20,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
   },
   sectionSubtitle: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginTop: 2,
   },
   sectionRightElement: {
     marginLeft: 16,
   },
-  
+
   // Loading Styles
   loadingOverlay: {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
     zIndex: 1000,
   },
   loadingContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   loadingCard: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     borderRadius: 20,
     padding: 30,
-    alignItems: 'center',
+    alignItems: "center",
     margin: 40,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 10 },
     shadowOpacity: 0.1,
     shadowRadius: 20,
@@ -329,32 +331,32 @@ const styles = StyleSheet.create({
   },
   loadingTitle: {
     fontSize: 18,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
     marginTop: 16,
     marginBottom: 8,
   },
   loadingSubtext: {
     fontSize: 14,
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
   },
-  
+
   // Empty State Styles
   emptyStateContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     padding: 40,
   },
   emptyStateCard: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     borderRadius: 20,
     padding: 40,
-    alignItems: 'center',
-    width: '100%',
+    alignItems: "center",
+    width: "100%",
     maxWidth: 300,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 5 },
     shadowOpacity: 0.1,
     shadowRadius: 15,
@@ -365,33 +367,33 @@ const styles = StyleSheet.create({
   },
   emptyStateTitle: {
     fontSize: 20,
-    fontWeight: 'bold',
-    color: '#000',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "#000",
+    textAlign: "center",
     marginBottom: 8,
   },
   emptyStateSubtitle: {
     fontSize: 16,
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
     lineHeight: 22,
     marginBottom: 24,
   },
   emptyStateButton: {
-    backgroundColor: '#8B5FBF',
+    backgroundColor: "#8B5FBF",
     paddingVertical: 12,
     paddingHorizontal: 24,
     borderRadius: 25,
-    shadowColor: '#8B5FBF',
+    shadowColor: "#8B5FBF",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 5,
   },
   emptyStateButtonText: {
-    color: 'white',
+    color: "white",
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: "600",
   },
 });
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,7 +10,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 
-const Layout = ({
+export function Layout({
   children,
   backgroundColor = "#FAFAFA",
   statusBarStyle = "dark-content",
@@ -19,7 +19,7 @@ const Layout = ({
   padding = 0,
   paddingHorizontal = 0,
   paddingVertical = 0,
-}) => {
+}) {
   return (
     <>
       <StatusBar
@@ -46,7 +46,7 @@ const Layout = ({
       </SafeAreaView>
     </>
   );
-};
+}
 
 // Modern Header Component for consistent headers across screens
 export const ModernHeader = ({
@@ -110,8 +110,6 @@ export const ModernCard = ({
   marginVertical = 0,
   backgroundColor = "white",
   borderRadius = 15,
-  shadowColor = "#000",
-  shadowOpacity = 0.05,
   elevation = 3,
   onPress,
 }) => {
@@ -124,8 +122,7 @@ export const ModernCard = ({
       marginVertical,
       backgroundColor,
       borderRadius,
-      shadowColor,
-      shadowOpacity,
+      boxShadow: "0px 2px 10px rgba(0,0,0,0.05)",
       elevation,
     },
     style,
@@ -271,9 +268,7 @@ const styles = StyleSheet.create({
 
   // Modern Card Styles
   modernCard: {
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 10,
-    // Android shadow
+    boxShadow: "0px 2px 10px rgba(0,0,0,0.05)",
     elevation: 3,
   },
 
@@ -323,10 +318,7 @@ const styles = StyleSheet.create({
     padding: 30,
     alignItems: "center",
     margin: 40,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 10 },
-    shadowOpacity: 0.1,
-    shadowRadius: 20,
+    boxShadow: "0px 10px 20px rgba(0,0,0,0.1)",
     elevation: 10,
   },
   loadingTitle: {
@@ -356,10 +348,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     width: "100%",
     maxWidth: 300,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 5 },
-    shadowOpacity: 0.1,
-    shadowRadius: 15,
+    boxShadow: "0px 5px 15px rgba(0,0,0,0.1)",
     elevation: 8,
   },
   emptyStateIcon: {
@@ -384,10 +373,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 24,
     borderRadius: 25,
-    shadowColor: "#8B5FBF",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
+    boxShadow: "0px 4px 8px rgba(139,95,191,0.3)",
     elevation: 5,
   },
   emptyStateButtonText: {
@@ -396,5 +382,3 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
 });
-
-export default Layout;

--- a/components/ProfileScreen.js
+++ b/components/ProfileScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -8,25 +8,21 @@ import {
   Alert,
   StyleSheet,
   Switch,
-} from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Feather } from '@expo/vector-icons';
-import { LinearGradient } from 'expo-linear-gradient';
-import Layout, { 
-  ModernHeader, 
-  ModernCard, 
-  SectionHeader 
-} from './Layout';
+} from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Feather } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import { Layout, ModernHeader, ModernCard, SectionHeader } from "./Layout";
 
 export default function ProfileScreen({ photos }) {
-  const [goal, setGoal] = useState('');
-  const [userName, setUserName] = useState('Sandra Glam');
-  const [userLocation, setUserLocation] = useState('Denmark, Copenhagen');
-  const [startWeight, setStartWeight] = useState('53.3');
-  const [goalWeight, setGoalWeight] = useState('50.0');
-  const [dailyCalories, setDailyCalories] = useState('740');
-  const [followers, setFollowers] = useState(72);
-  const [following, setFollowing] = useState(162);
+  const [goal, setGoal] = useState("");
+  const [userName, setUserName] = useState("Sandra Glam");
+  const [userLocation, setUserLocation] = useState("Denmark, Copenhagen");
+  const [startWeight, setStartWeight] = useState("53.3");
+  const [goalWeight, setGoalWeight] = useState("50.0");
+  const [dailyCalories, setDailyCalories] = useState("740");
+  const [followers] = useState(72);
+  const [following] = useState(162);
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [isEditingProfile, setIsEditingProfile] = useState(false);
 
@@ -36,48 +32,51 @@ export default function ProfileScreen({ photos }) {
 
   const loadUserData = async () => {
     try {
-      const savedGoal = await AsyncStorage.getItem('fitnessGoal');
-      const savedUserName = await AsyncStorage.getItem('userName');
-      const savedStartWeight = await AsyncStorage.getItem('startWeight');
-      const savedGoalWeight = await AsyncStorage.getItem('goalWeight');
-      
+      const savedGoal = await AsyncStorage.getItem("fitnessGoal");
+      const savedUserName = await AsyncStorage.getItem("userName");
+      const savedStartWeight = await AsyncStorage.getItem("startWeight");
+      const savedGoalWeight = await AsyncStorage.getItem("goalWeight");
+
       if (savedGoal) setGoal(savedGoal);
       if (savedUserName) setUserName(savedUserName);
       if (savedStartWeight) setStartWeight(savedStartWeight);
       if (savedGoalWeight) setGoalWeight(savedGoalWeight);
     } catch (error) {
-      console.error('Error loading user data:', error);
+      console.error("Error loading user data:", error);
     }
   };
 
   const saveUserData = async () => {
     try {
-      await AsyncStorage.setItem('fitnessGoal', goal);
-      await AsyncStorage.setItem('userName', userName);
-      await AsyncStorage.setItem('startWeight', startWeight);
-      await AsyncStorage.setItem('goalWeight', goalWeight);
-      
+      await AsyncStorage.setItem("fitnessGoal", goal);
+      await AsyncStorage.setItem("userName", userName);
+      await AsyncStorage.setItem("startWeight", startWeight);
+      await AsyncStorage.setItem("goalWeight", goalWeight);
+
       setIsEditingProfile(false);
-      Alert.alert('✅ Profile Updated!', 'Your changes have been saved successfully.');
+      Alert.alert(
+        "✅ Profile Updated!",
+        "Your changes have been saved successfully.",
+      );
     } catch (error) {
-      console.error('Error saving user data:', error);
-      Alert.alert('Error', 'Failed to save profile changes.');
+      console.error("Error saving user data:", error);
+      Alert.alert("Error", "Failed to save profile changes.");
     }
   };
 
   const getJourneyStats = () => {
     if (photos.length === 0) return { days: 0, thisMonth: 0 };
-    
+
     const firstPhoto = new Date(photos[0].timestamp);
     const now = new Date();
     const days = Math.ceil((now - firstPhoto) / (1000 * 60 * 60 * 24));
-    
+
     const monthAgo = new Date();
     monthAgo.setMonth(monthAgo.getMonth() - 1);
-    const thisMonth = photos.filter(photo => 
-      new Date(photo.timestamp) >= monthAgo
+    const thisMonth = photos.filter(
+      (photo) => new Date(photo.timestamp) >= monthAgo,
     ).length;
-    
+
     return { days, thisMonth };
   };
 
@@ -85,23 +84,23 @@ export default function ProfileScreen({ photos }) {
 
   const handleMenuPress = (item) => {
     switch (item) {
-      case 'physical':
-        Alert.alert('Physical Activity', 'Track your workouts and activities');
+      case "physical":
+        Alert.alert("Physical Activity", "Track your workouts and activities");
         break;
-      case 'statistics':
-        Alert.alert('Statistics', 'View detailed progress analytics');
+      case "statistics":
+        Alert.alert("Statistics", "View detailed progress analytics");
         break;
-      case 'routes':
-        Alert.alert('Routes', 'Explore workout routes and locations');
+      case "routes":
+        Alert.alert("Routes", "Explore workout routes and locations");
         break;
-      case 'bestTime':
-        Alert.alert('Best Time', 'Find your optimal workout times');
+      case "bestTime":
+        Alert.alert("Best Time", "Find your optimal workout times");
         break;
-      case 'equipment':
-        Alert.alert('Equipment', 'Manage your fitness equipment');
+      case "equipment":
+        Alert.alert("Equipment", "Manage your fitness equipment");
         break;
-      case 'settings':
-        Alert.alert('Settings', 'App preferences and configuration');
+      case "settings":
+        Alert.alert("Settings", "App preferences and configuration");
         break;
       default:
         break;
@@ -110,28 +109,34 @@ export default function ProfileScreen({ photos }) {
 
   return (
     <Layout backgroundColor="#FAFAFA">
-      <ModernHeader 
-        title="Profile" 
+      <ModernHeader
+        title="Profile"
         leftIcon={<Feather name="arrow-left" size={20} color="#666" />}
         rightIcon={<Feather name="settings" size={20} color="#666" />}
-        onRightPress={() => handleMenuPress('settings')}
+        onRightPress={() => handleMenuPress("settings")}
       />
 
-      <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={styles.scrollView}
+        showsVerticalScrollIndicator={false}
+      >
         {/* Profile Header */}
         <ModernCard style={styles.profileCard}>
           <View style={styles.profileHeader}>
             <View style={styles.avatarContainer}>
               <LinearGradient
-                colors={['#8B5FBF', '#6A4C93']}
+                colors={["#8B5FBF", "#6A4C93"]}
                 style={styles.avatarGradient}
               >
                 <Text style={styles.avatarText}>
-                  {userName.split(' ').map(n => n[0]).join('')}
+                  {userName
+                    .split(" ")
+                    .map((n) => n[0])
+                    .join("")}
                 </Text>
               </LinearGradient>
             </View>
-            
+
             <View style={styles.profileInfo}>
               {isEditingProfile ? (
                 <View style={styles.editingContainer}>
@@ -156,14 +161,18 @@ export default function ProfileScreen({ photos }) {
               )}
             </View>
 
-            <TouchableOpacity 
+            <TouchableOpacity
               style={styles.editButton}
-              onPress={isEditingProfile ? saveUserData : () => setIsEditingProfile(true)}
+              onPress={
+                isEditingProfile
+                  ? saveUserData
+                  : () => setIsEditingProfile(true)
+              }
             >
-              <Feather 
-                name={isEditingProfile ? "check" : "edit-2"} 
-                size={16} 
-                color="#8B5FBF" 
+              <Feather
+                name={isEditingProfile ? "check" : "edit-2"}
+                size={16}
+                color="#8B5FBF"
               />
             </TouchableOpacity>
           </View>
@@ -188,7 +197,7 @@ export default function ProfileScreen({ photos }) {
             {/* Start Weight */}
             <View style={styles.statCard}>
               <LinearGradient
-                colors={['#A8E6CF', '#7FCDCD']}
+                colors={["#A8E6CF", "#7FCDCD"]}
                 style={styles.statGradient}
               >
                 <Text style={styles.statLabel}>Start weight</Text>
@@ -209,7 +218,7 @@ export default function ProfileScreen({ photos }) {
             {/* Goal Weight */}
             <View style={styles.statCard}>
               <LinearGradient
-                colors={['#FFB347', '#FF8C42']}
+                colors={["#FFB347", "#FF8C42"]}
                 style={styles.statGradient}
               >
                 <Text style={styles.statLabel}>Goal</Text>
@@ -230,7 +239,7 @@ export default function ProfileScreen({ photos }) {
             {/* Daily Calories */}
             <View style={styles.statCard}>
               <LinearGradient
-                colors={['#8B5FBF', '#6A4C93']}
+                colors={["#8B5FBF", "#6A4C93"]}
                 style={styles.statGradient}
               >
                 <Text style={styles.statLabel}>Daily calories</Text>
@@ -252,7 +261,7 @@ export default function ProfileScreen({ photos }) {
 
         {/* Progress Stats */}
         <ModernCard style={styles.progressCard}>
-          <SectionHeader 
+          <SectionHeader
             title="Progress Overview"
             subtitle="Your fitness journey"
           />
@@ -266,7 +275,7 @@ export default function ProfileScreen({ photos }) {
                 <Text style={styles.progressLabel}>Journey started</Text>
               </View>
             </View>
-            
+
             <View style={styles.progressItem}>
               <View style={styles.progressIconContainer}>
                 <Feather name="camera" size={20} color="#FF8C42" />
@@ -276,13 +285,15 @@ export default function ProfileScreen({ photos }) {
                 <Text style={styles.progressLabel}>Progress captured</Text>
               </View>
             </View>
-            
+
             <View style={styles.progressItem}>
               <View style={styles.progressIconContainer}>
                 <Feather name="trending-up" size={20} color="#A8E6CF" />
               </View>
               <View style={styles.progressContent}>
-                <Text style={styles.progressValue}>{stats.thisMonth} this month</Text>
+                <Text style={styles.progressValue}>
+                  {stats.thisMonth} this month
+                </Text>
                 <Text style={styles.progressLabel}>Recent activity</Text>
               </View>
             </View>
@@ -291,7 +302,7 @@ export default function ProfileScreen({ photos }) {
 
         {/* Fitness Goal */}
         <ModernCard style={styles.goalCard}>
-          <SectionHeader 
+          <SectionHeader
             title="🎯 Fitness Goal"
             subtitle="What drives your journey"
           />
@@ -307,7 +318,8 @@ export default function ProfileScreen({ photos }) {
           ) : (
             <View style={styles.goalDisplay}>
               <Text style={styles.goalText}>
-                {goal || "Set your fitness goal to get personalized AI feedback!"}
+                {goal ||
+                  "Set your fitness goal to get personalized AI feedback!"}
               </Text>
             </View>
           )}
@@ -316,48 +328,52 @@ export default function ProfileScreen({ photos }) {
         {/* Menu Items */}
         <View style={styles.menuSection}>
           <SectionHeader title="Quick Actions" />
-          
+
           {/* Physical Activity */}
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.menuItem}
-            onPress={() => handleMenuPress('physical')}
+            onPress={() => handleMenuPress("physical")}
           >
             <View style={styles.menuItemLeft}>
-              <View style={[styles.menuIcon, { backgroundColor: '#E8F4FD' }]}>
+              <View style={[styles.menuIcon, { backgroundColor: "#E8F4FD" }]}>
                 <Feather name="activity" size={20} color="#4A90E2" />
               </View>
               <View style={styles.menuItemContent}>
                 <Text style={styles.menuItemTitle}>Physical activity</Text>
-                <Text style={styles.menuItemSubtitle}>{stats.thisMonth} days ago</Text>
+                <Text style={styles.menuItemSubtitle}>
+                  {stats.thisMonth} days ago
+                </Text>
               </View>
             </View>
             <Feather name="chevron-right" size={20} color="#C7C7CC" />
           </TouchableOpacity>
 
           {/* Statistics */}
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.menuItem}
-            onPress={() => handleMenuPress('statistics')}
+            onPress={() => handleMenuPress("statistics")}
           >
             <View style={styles.menuItemLeft}>
-              <View style={[styles.menuIcon, { backgroundColor: '#FFF3E0' }]}>
+              <View style={[styles.menuIcon, { backgroundColor: "#FFF3E0" }]}>
                 <Feather name="bar-chart-2" size={20} color="#FF8C42" />
               </View>
               <View style={styles.menuItemContent}>
                 <Text style={styles.menuItemTitle}>Statistics</Text>
-                <Text style={styles.menuItemSubtitle}>This year, {Math.floor(stats.days / 30)} months tracking</Text>
+                <Text style={styles.menuItemSubtitle}>
+                  This year, {Math.floor(stats.days / 30)} months tracking
+                </Text>
               </View>
             </View>
             <Feather name="chevron-right" size={20} color="#C7C7CC" />
           </TouchableOpacity>
 
           {/* Routes */}
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.menuItem}
-            onPress={() => handleMenuPress('routes')}
+            onPress={() => handleMenuPress("routes")}
           >
             <View style={styles.menuItemLeft}>
-              <View style={[styles.menuIcon, { backgroundColor: '#F3E5F5' }]}>
+              <View style={[styles.menuIcon, { backgroundColor: "#F3E5F5" }]}>
                 <Feather name="map-pin" size={20} color="#8B5FBF" />
               </View>
               <View style={styles.menuItemContent}>
@@ -369,12 +385,12 @@ export default function ProfileScreen({ photos }) {
           </TouchableOpacity>
 
           {/* Best Time */}
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.menuItem}
-            onPress={() => handleMenuPress('bestTime')}
+            onPress={() => handleMenuPress("bestTime")}
           >
             <View style={styles.menuItemLeft}>
-              <View style={[styles.menuIcon, { backgroundColor: '#E8F5E8' }]}>
+              <View style={[styles.menuIcon, { backgroundColor: "#E8F5E8" }]}>
                 <Feather name="clock" size={20} color="#4CAF50" />
               </View>
               <View style={styles.menuItemContent}>
@@ -386,17 +402,19 @@ export default function ProfileScreen({ photos }) {
           </TouchableOpacity>
 
           {/* Equipment */}
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.menuItem}
-            onPress={() => handleMenuPress('equipment')}
+            onPress={() => handleMenuPress("equipment")}
           >
             <View style={styles.menuItemLeft}>
-              <View style={[styles.menuIcon, { backgroundColor: '#FDE7E7' }]}>
+              <View style={[styles.menuIcon, { backgroundColor: "#FDE7E7" }]}>
                 <Feather name="target" size={20} color="#E57373" />
               </View>
               <View style={styles.menuItemContent}>
                 <Text style={styles.menuItemTitle}>Equipment</Text>
-                <Text style={styles.menuItemSubtitle}>Nike Pegasus 3000-130.4 km</Text>
+                <Text style={styles.menuItemSubtitle}>
+                  Nike Pegasus 3000-130.4 km
+                </Text>
               </View>
             </View>
             <Feather name="chevron-right" size={20} color="#C7C7CC" />
@@ -406,7 +424,7 @@ export default function ProfileScreen({ photos }) {
         {/* Settings */}
         <ModernCard style={styles.settingsCard}>
           <SectionHeader title="Preferences" />
-          
+
           <View style={styles.settingItem}>
             <View style={styles.settingLeft}>
               <Feather name="bell" size={20} color="#8B5FBF" />
@@ -415,8 +433,8 @@ export default function ProfileScreen({ photos }) {
             <Switch
               value={notificationsEnabled}
               onValueChange={setNotificationsEnabled}
-              trackColor={{ false: '#E0E0E0', true: '#8B5FBF' }}
-              thumbColor={notificationsEnabled ? 'white' : '#f4f3f4'}
+              trackColor={{ false: "#E0E0E0", true: "#8B5FBF" }}
+              thumbColor={notificationsEnabled ? "white" : "#f4f3f4"}
             />
           </View>
         </ModernCard>
@@ -440,8 +458,8 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   profileHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     marginBottom: 20,
   },
   avatarContainer: {
@@ -451,79 +469,79 @@ const styles = StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   avatarText: {
     fontSize: 22,
-    fontWeight: 'bold',
-    color: 'white',
+    fontWeight: "bold",
+    color: "white",
   },
   profileInfo: {
     flex: 1,
   },
   userName: {
     fontSize: 20,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
     marginBottom: 4,
   },
   userLocation: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
   },
   editingContainer: {
     flex: 1,
   },
   nameInput: {
     fontSize: 20,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
     borderBottomWidth: 1,
-    borderBottomColor: '#E0E0E0',
+    borderBottomColor: "#E0E0E0",
     paddingVertical: 4,
     marginBottom: 8,
   },
   locationInput: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     borderBottomWidth: 1,
-    borderBottomColor: '#E0E0E0',
+    borderBottomColor: "#E0E0E0",
     paddingVertical: 4,
   },
   editButton: {
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: '#F8F9FF',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#F8F9FF",
+    justifyContent: "center",
+    alignItems: "center",
   },
   followStats: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingTop: 20,
     borderTopWidth: 1,
-    borderTopColor: '#F0F0F0',
+    borderTopColor: "#F0F0F0",
   },
   followItem: {
     flex: 1,
-    alignItems: 'center',
+    alignItems: "center",
   },
   followNumber: {
     fontSize: 20,
-    fontWeight: 'bold',
-    color: '#000',
+    fontWeight: "bold",
+    color: "#000",
   },
   followLabel: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginTop: 4,
   },
   followDivider: {
     width: 1,
     height: 30,
-    backgroundColor: '#E0E0E0',
+    backgroundColor: "#E0E0E0",
     marginHorizontal: 20,
   },
 
@@ -532,45 +550,42 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   statsGrid: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    justifyContent: "space-between",
   },
   statCard: {
     flex: 1,
     marginHorizontal: 4,
     borderRadius: 15,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
+    overflow: "hidden",
+    boxShadow: "0px 4px 8px rgba(0,0,0,0.1)",
     elevation: 5,
   },
   statGradient: {
     padding: 16,
-    alignItems: 'center',
+    alignItems: "center",
     minHeight: 80,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   statLabel: {
     fontSize: 12,
-    color: 'rgba(255,255,255,0.8)',
+    color: "rgba(255,255,255,0.8)",
     marginBottom: 8,
-    textAlign: 'center',
+    textAlign: "center",
   },
   statValue: {
     fontSize: 16,
-    fontWeight: 'bold',
-    color: 'white',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "white",
+    textAlign: "center",
   },
   statInput: {
     fontSize: 16,
-    fontWeight: 'bold',
-    color: 'white',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "white",
+    textAlign: "center",
     borderBottomWidth: 1,
-    borderBottomColor: 'rgba(255,255,255,0.5)',
+    borderBottomColor: "rgba(255,255,255,0.5)",
     paddingVertical: 4,
     minWidth: 60,
   },
@@ -584,17 +599,17 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
   progressItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     marginBottom: 16,
   },
   progressIconContainer: {
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#F8F9FF',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#F8F9FF",
+    justifyContent: "center",
+    alignItems: "center",
     marginRight: 16,
   },
   progressContent: {
@@ -602,12 +617,12 @@ const styles = StyleSheet.create({
   },
   progressValue: {
     fontSize: 16,
-    fontWeight: '600',
-    color: '#000',
+    fontWeight: "600",
+    color: "#000",
   },
   progressLabel: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginTop: 2,
   },
 
@@ -618,24 +633,24 @@ const styles = StyleSheet.create({
   },
   goalInput: {
     borderWidth: 1,
-    borderColor: '#E0E0E0',
+    borderColor: "#E0E0E0",
     borderRadius: 12,
     padding: 16,
     fontSize: 16,
     minHeight: 100,
-    textAlignVertical: 'top',
-    backgroundColor: '#F8F9FA',
+    textAlignVertical: "top",
+    backgroundColor: "#F8F9FA",
     marginTop: 12,
   },
   goalDisplay: {
-    backgroundColor: '#F8F9FA',
+    backgroundColor: "#F8F9FA",
     borderRadius: 12,
     padding: 16,
     marginTop: 12,
   },
   goalText: {
     fontSize: 16,
-    color: '#333',
+    color: "#333",
     lineHeight: 24,
   },
 
@@ -644,30 +659,27 @@ const styles = StyleSheet.create({
     marginBottom: 24,
   },
   menuItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: 'white',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "white",
     borderRadius: 12,
     padding: 16,
     marginBottom: 8,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 8,
+    boxShadow: "0px 2px 8px rgba(0,0,0,0.05)",
     elevation: 2,
   },
   menuItemLeft: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     flex: 1,
   },
   menuIcon: {
     width: 40,
     height: 40,
     borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     marginRight: 16,
   },
   menuItemContent: {
@@ -675,12 +687,12 @@ const styles = StyleSheet.create({
   },
   menuItemTitle: {
     fontSize: 16,
-    fontWeight: '600',
-    color: '#000',
+    fontWeight: "600",
+    color: "#000",
   },
   menuItemSubtitle: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginTop: 2,
   },
 
@@ -690,19 +702,19 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   settingItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
     paddingVertical: 8,
   },
   settingLeft: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     flex: 1,
   },
   settingText: {
     fontSize: 16,
-    color: '#000',
+    color: "#000",
     marginLeft: 12,
   },
 

--- a/components/ProgressScreen.js
+++ b/components/ProgressScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -8,72 +8,82 @@ import {
   Alert,
   Dimensions,
   StyleSheet,
-} from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Feather } from '@expo/vector-icons';
-import { LinearGradient } from 'expo-linear-gradient';
-import Layout, { 
-  ModernHeader, 
-  ModernCard, 
-  SectionHeader, 
-  EmptyState 
-} from './Layout';
+} from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Feather } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import {
+  Layout,
+  ModernHeader,
+  ModernCard,
+  SectionHeader,
+  EmptyState,
+} from "./Layout";
 
-const { width: screenWidth } = Dimensions.get('window');
+const { width: screenWidth } = Dimensions.get("window");
 const photoWidth = (screenWidth - 60) / 2; // 2 columns with padding
 
 export default function ProgressScreen({ photos, setPhotos }) {
   const [compareMode, setCompareMode] = useState(false);
   const [selectedPhotos, setSelectedPhotos] = useState([]);
-  const [viewMode, setViewMode] = useState('grid'); // 'grid' or 'list'
+  const [viewMode, setViewMode] = useState("grid"); // 'grid' or 'list'
 
   const formatDate = (timestamp) => {
     const date = new Date(timestamp);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
     });
   };
 
   const formatTime = (timestamp) => {
     const date = new Date(timestamp);
-    return date.toLocaleDateString('en-US', {
-      month: 'long',
-      day: 'numeric'
+    return date.toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
     });
   };
 
   const deletePhoto = (photoId) => {
     Alert.alert(
-      'Delete Photo',
-      'Are you sure you want to delete this progress photo?',
+      "Delete Photo",
+      "Are you sure you want to delete this progress photo?",
       [
-        { text: 'Cancel', style: 'cancel' },
+        { text: "Cancel", style: "cancel" },
         {
-          text: 'Delete',
-          style: 'destructive',
+          text: "Delete",
+          style: "destructive",
           onPress: async () => {
             try {
-              const photoToDelete = photos.find(photo => photo.id === photoId);
+              const photoToDelete = photos.find(
+                (photo) => photo.id === photoId,
+              );
               if (photoToDelete) {
                 // Delete the actual file
-                const fileInfo = await FileSystem.getInfoAsync(photoToDelete.uri);
+                const fileInfo = await FileSystem.getInfoAsync(
+                  photoToDelete.uri,
+                );
                 if (fileInfo.exists) {
                   await FileSystem.deleteAsync(photoToDelete.uri);
                 }
               }
-              
-              const updatedPhotos = photos.filter(photo => photo.id !== photoId);
+
+              const updatedPhotos = photos.filter(
+                (photo) => photo.id !== photoId,
+              );
               setPhotos(updatedPhotos);
-              await AsyncStorage.setItem('progressPhotos', JSON.stringify(updatedPhotos));
+              await AsyncStorage.setItem(
+                "progressPhotos",
+                JSON.stringify(updatedPhotos),
+              );
             } catch (error) {
-              console.error('Error deleting photo:', error);
-              Alert.alert('Error', 'Failed to delete photo.');
+              console.error("Error deleting photo:", error);
+              Alert.alert("Error", "Failed to delete photo.");
             }
           },
         },
-      ]
+      ],
     );
   };
 
@@ -97,20 +107,22 @@ export default function ProgressScreen({ photos, setPhotos }) {
   };
 
   const isPhotoSelected = (photoId) => {
-    return selectedPhotos.some(photo => photo.id === photoId);
+    return selectedPhotos.some((photo) => photo.id === photoId);
   };
 
   const getProgressStats = () => {
     if (photos.length === 0) return null;
-    
+
     const firstPhoto = new Date(photos[0].timestamp);
     const latestPhoto = new Date(photos[photos.length - 1].timestamp);
-    const daysDifference = Math.ceil((latestPhoto - firstPhoto) / (1000 * 60 * 60 * 24));
-    
+    const daysDifference = Math.ceil(
+      (latestPhoto - firstPhoto) / (1000 * 60 * 60 * 24),
+    );
+
     return {
       totalPhotos: photos.length,
       daysSinceStart: daysDifference,
-      thisWeek: photos.filter(photo => {
+      thisWeek: photos.filter((photo) => {
         const photoDate = new Date(photo.timestamp);
         const weekAgo = new Date();
         weekAgo.setDate(weekAgo.getDate() - 7);
@@ -125,8 +137,8 @@ export default function ProgressScreen({ photos, setPhotos }) {
   if (photos.length === 0) {
     return (
       <Layout>
-        <ModernHeader 
-          title="Progress" 
+        <ModernHeader
+          title="Progress"
           subtitle="Your fitness journey"
           rightIcon={<Feather name="camera" size={20} color="#666" />}
         />
@@ -137,7 +149,10 @@ export default function ProgressScreen({ photos, setPhotos }) {
           buttonText="Take First Photo"
           onButtonPress={() => {
             // Navigate to camera tab - you'll need to implement navigation
-            Alert.alert('Tip', 'Go to the Camera tab to take your first photo!');
+            Alert.alert(
+              "Tip",
+              "Go to the Camera tab to take your first photo!",
+            );
           }}
         />
       </Layout>
@@ -146,63 +161,69 @@ export default function ProgressScreen({ photos, setPhotos }) {
 
   return (
     <Layout backgroundColor="#FAFAFA">
-      <ModernHeader 
-        title="Progress" 
-        subtitle={`${photos.length} ${photos.length === 1 ? 'photo' : 'photos'} captured`}
+      <ModernHeader
+        title="Progress"
+        subtitle={`${photos.length} ${photos.length === 1 ? "photo" : "photos"} captured`}
         rightIcon={
           <View style={styles.headerActions}>
-            <TouchableOpacity 
-              style={[styles.actionButton, compareMode && styles.actionButtonActive]}
+            <TouchableOpacity
+              style={[
+                styles.actionButton,
+                compareMode && styles.actionButtonActive,
+              ]}
               onPress={toggleCompareMode}
             >
-              <Feather 
-                name={compareMode ? "x" : "layers"} 
-                size={18} 
-                color={compareMode ? "#fff" : "#666"} 
+              <Feather
+                name={compareMode ? "x" : "layers"}
+                size={18}
+                color={compareMode ? "#fff" : "#666"}
               />
             </TouchableOpacity>
-            <TouchableOpacity 
+            <TouchableOpacity
               style={styles.actionButton}
-              onPress={() => setViewMode(viewMode === 'grid' ? 'list' : 'grid')}
+              onPress={() => setViewMode(viewMode === "grid" ? "list" : "grid")}
             >
-              <Feather 
-                name={viewMode === 'grid' ? "list" : "grid"} 
-                size={18} 
-                color="#666" 
+              <Feather
+                name={viewMode === "grid" ? "list" : "grid"}
+                size={18}
+                color="#666"
               />
             </TouchableOpacity>
           </View>
         }
       />
 
-      <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={styles.scrollView}
+        showsVerticalScrollIndicator={false}
+      >
         {/* Stats Cards */}
         {stats && (
           <View style={styles.statsContainer}>
             <View style={styles.statsGrid}>
               <View style={styles.statCard}>
                 <LinearGradient
-                  colors={['#8B5FBF', '#6A4C93']}
+                  colors={["#8B5FBF", "#6A4C93"]}
                   style={styles.statGradient}
                 >
                   <Text style={styles.statNumber}>{stats.totalPhotos}</Text>
                   <Text style={styles.statLabel}>Total Photos</Text>
                 </LinearGradient>
               </View>
-              
+
               <View style={styles.statCard}>
                 <LinearGradient
-                  colors={['#FF9A56', '#FF6B35']}
+                  colors={["#FF9A56", "#FF6B35"]}
                   style={styles.statGradient}
                 >
                   <Text style={styles.statNumber}>{stats.daysSinceStart}</Text>
                   <Text style={styles.statLabel}>Days Tracking</Text>
                 </LinearGradient>
               </View>
-              
+
               <View style={styles.statCard}>
                 <LinearGradient
-                  colors={['#A8E6CF', '#7FCDCD']}
+                  colors={["#A8E6CF", "#7FCDCD"]}
                   style={styles.statGradient}
                 >
                   <Text style={styles.statNumber}>{stats.thisWeek}</Text>
@@ -221,12 +242,17 @@ export default function ProgressScreen({ photos, setPhotos }) {
               {selectedPhotos.map((photo, index) => (
                 <View key={photo.id} style={styles.comparisonPhotoContainer}>
                   <Text style={styles.comparisonPhotoLabel}>
-                    {index === 0 ? 'Earlier' : 'Latest'}
+                    {index === 0 ? "Earlier" : "Latest"}
                   </Text>
                   <View style={styles.comparisonPhotoCard}>
-                    <Image source={{ uri: photo.uri }} style={styles.comparisonPhoto} />
+                    <Image
+                      source={{ uri: photo.uri }}
+                      style={styles.comparisonPhoto}
+                    />
                     <View style={styles.comparisonPhotoOverlay}>
-                      <Text style={styles.comparisonDateText}>{formatDate(photo.timestamp)}</Text>
+                      <Text style={styles.comparisonDateText}>
+                        {formatDate(photo.timestamp)}
+                      </Text>
                     </View>
                   </View>
                 </View>
@@ -241,17 +267,19 @@ export default function ProgressScreen({ photos, setPhotos }) {
             <View style={styles.instructionsContent}>
               <Feather name="info" size={20} color="#8B5FBF" />
               <Text style={styles.instructionsText}>
-                {selectedPhotos.length === 0 ? 'Select two photos to compare your progress' : 
-                 selectedPhotos.length === 1 ? 'Select one more photo to compare' : 
-                 'Great! Your comparison is ready above'}
+                {selectedPhotos.length === 0
+                  ? "Select two photos to compare your progress"
+                  : selectedPhotos.length === 1
+                    ? "Select one more photo to compare"
+                    : "Great! Your comparison is ready above"}
               </Text>
             </View>
           </ModernCard>
         )}
 
         {/* Photos Section */}
-        <SectionHeader 
-          title="All Photos" 
+        <SectionHeader
+          title="All Photos"
           subtitle={`Sorted by newest first`}
           rightElement={
             <TouchableOpacity onPress={() => {}}>
@@ -261,59 +289,78 @@ export default function ProgressScreen({ photos, setPhotos }) {
         />
 
         {/* Photo Grid/List */}
-        <View style={viewMode === 'grid' ? styles.photoGrid : styles.photoList}>
-          {photos.slice().reverse().map((photo, index) => (
-            <TouchableOpacity
-              key={photo.id}
-              style={[
-                viewMode === 'grid' ? styles.photoGridItem : styles.photoListItem,
-                compareMode && styles.photoSelectable,
-                isPhotoSelected(photo.id) && styles.photoSelected,
-              ]}
-              onPress={compareMode ? () => selectPhotoForComparison(photo) : undefined}
-              onLongPress={!compareMode ? () => deletePhoto(photo.id) : undefined}
-              activeOpacity={0.9}
-            >
-              {/* Selection Badge */}
-              {isPhotoSelected(photo.id) && (
-                <View style={styles.selectionBadge}>
-                  <Feather name="check" size={16} color="white" />
-                </View>
-              )}
-
-              {/* Photo */}
-              <View style={styles.photoContainer}>
-                <Image 
-                  source={{ uri: photo.uri }} 
-                  style={viewMode === 'grid' ? styles.gridPhotoImage : styles.listPhotoImage} 
-                />
-                
-                {/* Photo Overlay */}
-                <LinearGradient
-                  colors={['transparent', 'rgba(0,0,0,0.7)']}
-                  style={styles.photoOverlay}
-                >
-                  <View style={styles.photoInfo}>
-                    <Text style={styles.photoNumber}>#{photos.length - index}</Text>
-                    <Text style={styles.photoDate}>{formatTime(photo.timestamp)}</Text>
+        <View style={viewMode === "grid" ? styles.photoGrid : styles.photoList}>
+          {photos
+            .slice()
+            .reverse()
+            .map((photo, index) => (
+              <TouchableOpacity
+                key={photo.id}
+                style={[
+                  viewMode === "grid"
+                    ? styles.photoGridItem
+                    : styles.photoListItem,
+                  compareMode && styles.photoSelectable,
+                  isPhotoSelected(photo.id) && styles.photoSelected,
+                ]}
+                onPress={
+                  compareMode
+                    ? () => selectPhotoForComparison(photo)
+                    : undefined
+                }
+                onLongPress={
+                  !compareMode ? () => deletePhoto(photo.id) : undefined
+                }
+                activeOpacity={0.9}
+              >
+                {/* Selection Badge */}
+                {isPhotoSelected(photo.id) && (
+                  <View style={styles.selectionBadge}>
+                    <Feather name="check" size={16} color="white" />
                   </View>
-                </LinearGradient>
-              </View>
+                )}
 
-              {/* Analysis (List view only) */}
-              {viewMode === 'list' && !compareMode && photo.analysis && (
-                <View style={styles.analysisContainer}>
-                  <View style={styles.analysisHeader}>
-                    <Feather name="zap" size={16} color="#8B5FBF" />
-                    <Text style={styles.analysisTitle}>AI Analysis</Text>
-                  </View>
-                  <Text style={styles.analysisText} numberOfLines={3}>
-                    {photo.analysis}
-                  </Text>
+                {/* Photo */}
+                <View style={styles.photoContainer}>
+                  <Image
+                    source={{ uri: photo.uri }}
+                    style={
+                      viewMode === "grid"
+                        ? styles.gridPhotoImage
+                        : styles.listPhotoImage
+                    }
+                  />
+
+                  {/* Photo Overlay */}
+                  <LinearGradient
+                    colors={["transparent", "rgba(0,0,0,0.7)"]}
+                    style={styles.photoOverlay}
+                  >
+                    <View style={styles.photoInfo}>
+                      <Text style={styles.photoNumber}>
+                        #{photos.length - index}
+                      </Text>
+                      <Text style={styles.photoDate}>
+                        {formatTime(photo.timestamp)}
+                      </Text>
+                    </View>
+                  </LinearGradient>
                 </View>
-              )}
-            </TouchableOpacity>
-          ))}
+
+                {/* Analysis (List view only) */}
+                {viewMode === "list" && !compareMode && photo.analysis && (
+                  <View style={styles.analysisContainer}>
+                    <View style={styles.analysisHeader}>
+                      <Feather name="zap" size={16} color="#8B5FBF" />
+                      <Text style={styles.analysisTitle}>AI Analysis</Text>
+                    </View>
+                    <Text style={styles.analysisText} numberOfLines={3}>
+                      {photo.analysis}
+                    </Text>
+                  </View>
+                )}
+              </TouchableOpacity>
+            ))}
         </View>
 
         {/* Bottom Spacing */}
@@ -327,23 +374,23 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
   },
-  
+
   // Header Actions
   headerActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
   },
   actionButton: {
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: '#F5F5F5',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#F5F5F5",
+    justifyContent: "center",
+    alignItems: "center",
     marginLeft: 8,
   },
   actionButtonActive: {
-    backgroundColor: '#8B5FBF',
+    backgroundColor: "#8B5FBF",
   },
 
   // Stats
@@ -352,37 +399,34 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   statsGrid: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    justifyContent: "space-between",
   },
   statCard: {
     flex: 1,
     marginHorizontal: 4,
     borderRadius: 15,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
+    overflow: "hidden",
+    boxShadow: "0px 4px 8px rgba(0,0,0,0.1)",
     elevation: 5,
   },
   statGradient: {
     padding: 16,
-    alignItems: 'center',
+    alignItems: "center",
     minHeight: 80,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   statNumber: {
     fontSize: 24,
-    fontWeight: 'bold',
-    color: 'white',
+    fontWeight: "bold",
+    color: "white",
     marginBottom: 4,
   },
   statLabel: {
     fontSize: 12,
-    color: 'rgba(255,255,255,0.9)',
-    textAlign: 'center',
-    fontWeight: '500',
+    color: "rgba(255,255,255,0.9)",
+    textAlign: "center",
+    fontWeight: "500",
   },
 
   // Comparison
@@ -393,87 +437,84 @@ const styles = StyleSheet.create({
   },
   comparisonTitle: {
     fontSize: 18,
-    fontWeight: 'bold',
-    color: '#000',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "#000",
+    textAlign: "center",
     marginBottom: 20,
   },
   comparisonPhotos: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
+    flexDirection: "row",
+    justifyContent: "space-around",
   },
   comparisonPhotoContainer: {
-    alignItems: 'center',
+    alignItems: "center",
     flex: 1,
     marginHorizontal: 8,
   },
   comparisonPhotoLabel: {
     fontSize: 14,
-    fontWeight: '600',
-    color: '#8B5FBF',
+    fontWeight: "600",
+    color: "#8B5FBF",
     marginBottom: 8,
   },
   comparisonPhotoCard: {
     borderRadius: 12,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.15,
-    shadowRadius: 8,
+    overflow: "hidden",
+    boxShadow: "0px 4px 8px rgba(0,0,0,0.15)",
     elevation: 5,
   },
   comparisonPhoto: {
     width: 120,
     height: 160,
-    resizeMode: 'cover',
+    resizeMode: "cover",
   },
   comparisonPhotoOverlay: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: 'rgba(0,0,0,0.7)',
+    backgroundColor: "rgba(0,0,0,0.7)",
     padding: 8,
   },
   comparisonDateText: {
-    color: 'white',
+    color: "white",
     fontSize: 11,
-    fontWeight: '600',
-    textAlign: 'center',
+    fontWeight: "600",
+    textAlign: "center",
   },
 
   // Instructions
   instructionsCard: {
     marginHorizontal: 20,
     marginBottom: 20,
-    backgroundColor: '#F8F9FF',
+    backgroundColor: "#F8F9FF",
     borderWidth: 1,
-    borderColor: '#E8EAFF',
+    borderColor: "#E8EAFF",
   },
   instructionsContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     padding: 16,
   },
   instructionsText: {
     flex: 1,
     marginLeft: 12,
     fontSize: 14,
-    color: '#8B5FBF',
-    fontWeight: '500',
+    color: "#8B5FBF",
+    fontWeight: "500",
   },
 
   // Section Action
   sectionAction: {
     fontSize: 14,
-    color: '#8B5FBF',
-    fontWeight: '600',
+    color: "#8B5FBF",
+    fontWeight: "600",
   },
 
   // Photo Grid
   photoGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+    flexDirection: "row",
+    flexWrap: "wrap",
     paddingHorizontal: 16,
     marginTop: 8,
   },
@@ -482,12 +523,9 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     marginHorizontal: 4,
     borderRadius: 15,
-    overflow: 'hidden',
-    backgroundColor: 'white',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
+    overflow: "hidden",
+    backgroundColor: "white",
+    boxShadow: "0px 4px 8px rgba(0,0,0,0.1)",
     elevation: 5,
   },
 
@@ -497,87 +535,80 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
   photoListItem: {
-    backgroundColor: 'white',
+    backgroundColor: "white",
     borderRadius: 15,
     marginBottom: 16,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
+    overflow: "hidden",
+    boxShadow: "0px 4px 8px rgba(0,0,0,0.1)",
     elevation: 5,
   },
 
   // Photo Selection
   photoSelectable: {
     borderWidth: 2,
-    borderColor: '#E0E0E0',
+    borderColor: "#E0E0E0",
   },
   photoSelected: {
-    borderColor: '#8B5FBF',
+    borderColor: "#8B5FBF",
     borderWidth: 3,
-    shadowColor: '#8B5FBF',
-    shadowOpacity: 0.3,
+    boxShadow: "0px 0px 0px rgba(139,95,191,0.3)",
   },
   selectionBadge: {
-    position: 'absolute',
+    position: "absolute",
     top: 12,
     right: 12,
     width: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: '#8B5FBF',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#8B5FBF",
+    justifyContent: "center",
+    alignItems: "center",
     zIndex: 10,
-    shadowColor: '#8B5FBF',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.5,
-    shadowRadius: 4,
+    boxShadow: "0px 2px 4px rgba(139,95,191,0.5)",
     elevation: 8,
   },
 
   // Photo Container
   photoContainer: {
-    position: 'relative',
+    position: "relative",
   },
   gridPhotoImage: {
-    width: '100%',
+    width: "100%",
     height: photoWidth * 1.3,
-    resizeMode: 'cover',
+    resizeMode: "cover",
   },
   listPhotoImage: {
-    width: '100%',
+    width: "100%",
     height: 250,
-    resizeMode: 'cover',
+    resizeMode: "cover",
   },
   photoOverlay: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
     height: 60,
-    justifyContent: 'flex-end',
+    justifyContent: "flex-end",
     padding: 12,
   },
   photoInfo: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   photoNumber: {
     fontSize: 14,
-    fontWeight: 'bold',
-    color: 'white',
-    backgroundColor: 'rgba(139, 95, 191, 0.9)',
+    fontWeight: "bold",
+    color: "white",
+    backgroundColor: "rgba(139, 95, 191, 0.9)",
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 12,
   },
   photoDate: {
     fontSize: 12,
-    color: 'white',
-    fontWeight: '600',
+    color: "white",
+    fontWeight: "600",
   },
 
   // Analysis
@@ -585,19 +616,19 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   analysisHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     marginBottom: 8,
   },
   analysisTitle: {
     fontSize: 14,
-    fontWeight: '600',
-    color: '#8B5FBF',
+    fontWeight: "600",
+    color: "#8B5FBF",
     marginLeft: 6,
   },
   analysisText: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     lineHeight: 20,
   },
 


### PR DESCRIPTION
## Summary
- replace tab home page with new PhotoProgressApp layout
- use simple emoji icon components instead of external library
- fix React Native imports and escape apostrophe in progress title

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe14ec8a883238e16f1288e8a1574