### PR TITLE
feat: add capture fit profile page

### DIFF
--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { View, Text, Image, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
-// eslint-disable-next-line import/no-unresolved
 import Svg, { Circle } from 'react-native-svg';
 import { Feather } from '@expo/vector-icons';
 
@@ -98,7 +97,7 @@ export default function Homepage() {
 
         <View style={styles.statsGrid}>
           <View style={styles.statCard}>
-            <Feather name="fire" size={24} color={theme.colors.primary} />
+            <Feather name="zap" size={24} color={theme.colors.primary} />
             <View style={styles.statInfo}>
               <Text style={styles.statValue}>350</Text>
               <Text style={styles.statLabel}>Calories</Text>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,8 +1,6 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import ProfileScreen from '@/components/ProfileScreen';
-import { PhotoContext } from './_layout';
 
 export default function ProfilePage() {
-  const { photos } = useContext(PhotoContext);
-  return <ProfileScreen photos={photos} />;
+  return <ProfileScreen />;
 }

--- a/components/CameraScreen.js
+++ b/components/CameraScreen.js
@@ -24,7 +24,6 @@ const OPENAI_API_KEY = 'your-api-key-here'; // Replace with your actual key
 export default function CameraScreen({ photos, setPhotos, loading, setLoading }) {
   const [cameraPermission, setCameraPermission] = useState(null);
   const [showWelcome, setShowWelcome] = useState(true);
-  const [currentDate, setCurrentDate] = useState(new Date());
 
   useEffect(() => {
     getCameraPermission();
@@ -250,7 +249,7 @@ export default function CameraScreen({ photos, setPhotos, loading, setLoading })
             />
             <View style={styles.greetingContainer}>
               <Text style={styles.greeting}>Hello, User</Text>
-              <Text style={styles.date}>Today {currentDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short' })}</Text>
+              <Text style={styles.date}>Today {new Date().toLocaleDateString('en-US', { day: 'numeric', month: 'short' })}</Text>
             </View>
           </View>
           <TouchableOpacity style={styles.searchButton}>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -5,6 +5,9 @@ import {
   StatusBar,
   Platform,
   StyleSheet,
+  TouchableOpacity,
+  Text,
+  ActivityIndicator,
 } from 'react-native';
 
 const Layout = ({ 

--- a/package.json
+++ b/package.json
@@ -12,15 +12,20 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.20",
     "expo-blur": "~14.1.5",
+    "expo-camera": "~16.1.11",
     "expo-constants": "~17.1.7",
+    "expo-file-system": "~18.1.11",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
+    "expo-image-picker": "~16.1.4",
+    "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.4",
     "expo-splash-screen": "~0.30.10",
@@ -35,21 +40,17 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
+    "react-native-svg": "15.11.2",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "@react-native-async-storage/async-storage": "2.1.2",
-    "expo-camera": "~16.1.11",
-    "expo-file-system": "~18.1.11",
-    "expo-image-picker": "~16.1.4",
-    "expo-linear-gradient": "~14.1.5",
-    "react-native-svg": "15.11.2"
+    "lucide-react-native": "^0.379.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "typescript": "~5.8.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- rebuild profile screen as React Native CaptureFitProfile component styled like the updated home layout
- switch profile icons to lucide-react-native to resolve invalid element errors
- declare lucide-react-native dependency for icon support

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lucide-react-native)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unable to resolve path to module 'lucide-react-native')*


------
https://chatgpt.com/codex/tasks/task_e_68900c6968c48323a0b5509d05956198