### PR TITLE
Fix stat card width calculation on profile screen

### DIFF
--- a/components/ProfileScreen.js
+++ b/components/ProfileScreen.js
@@ -16,9 +16,17 @@ import { LinearGradient } from 'expo-linear-gradient';
 import Layout from './Layout';
 
 const screenWidth = Dimensions.get('window').width;
+const PROFILE_CARD_MARGIN = 24;
+const PROFILE_CARD_PADDING = 24;
 const H_PADDING = 24;
 const GAP = 16;
-const cardWidth = (screenWidth - 100) / 3;
+const cardWidth =
+  (screenWidth -
+    2 * PROFILE_CARD_MARGIN -
+    2 * PROFILE_CARD_PADDING -
+    2 * H_PADDING -
+    2 * GAP) /
+  3;
 
 const CaptureFitProfile = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -363,10 +371,10 @@ const styles = StyleSheet.create({
     color: '#111827',
   },
   profileCard: {
-    marginHorizontal: 24,
+    marginHorizontal: PROFILE_CARD_MARGIN,
     backgroundColor: '#fff',
     borderRadius: 24,
-    padding: 24,
+    padding: PROFILE_CARD_PADDING,
     shadowColor: '#000',
     shadowOpacity: 0.05,
     shadowRadius: 6,


### PR DESCRIPTION
## Summary
- calculate stat card width based on actual profile card and stats row paddings and margins
- use constants for profile card spacing values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `node -e "const screenWidth=320;const PROFILE_CARD_MARGIN=24;const PROFILE_CARD_PADDING=24;const H_PADDING=24;const GAP=16;const cardWidth=(screenWidth-2*PROFILE_CARD_MARGIN-2*PROFILE_CARD_PADDING-2*H_PADDING-2*GAP)/3;console.log({cardWidth,total:cardWidth*3+2*GAP});"`


------
https://chatgpt.com/codex/tasks/task_e_68951b7fe51883239aa75c97b7be4c9b