### PR TITLE
Use PhotoContext on homepage to prevent undefined photos

### DIFF
--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,1 +1,16 @@
-export { default } from '../../components/CameraScreen';
+import React, { useContext } from "react";
+import CameraScreen from "@/components/CameraScreen";
+import { PhotoContext } from "./_layout";
+
+export default function HomePage() {
+  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
+  return (
+    <CameraScreen
+      photos={photos}
+      setPhotos={setPhotos}
+      loading={loading}
+      setLoading={setLoading}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- Use `PhotoContext` on homepage screen so `CameraScreen` receives photos and loading state, preventing undefined access errors.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952f464dc88323b3f9dcc442083cef