### PR TITLE
Fix home tab routing and add dedicated HomeScreen

### DIFF
--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -1,8 +1,16 @@
 import React, { useContext } from "react";
-import ProgressScreen from "@/components/ProgressScreen";
+import CameraScreen from "@/components/CameraScreen";
 import { PhotoContext } from "./_layout";
 
 export default function CameraPage() {
-  const { photos, setPhotos } = useContext(PhotoContext);
-  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
+  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
+  return (
+    <CameraScreen
+      photos={photos}
+      setPhotos={setPhotos}
+      loading={loading}
+      setLoading={setLoading}
+    />
+  );
 }
+

--- a/app/(tabs)/homepage.tsx
+++ b/app/(tabs)/homepage.tsx
@@ -1,16 +1,7 @@
-import React, { useContext } from "react";
-import CameraScreen from "@/components/CameraScreen";
-import { PhotoContext } from "./_layout";
+import React from "react";
+import HomeScreen from "@/components/HomeScreen";
 
 export default function HomePage() {
-  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
-  return (
-    <CameraScreen
-      photos={photos}
-      setPhotos={setPhotos}
-      loading={loading}
-      setLoading={setLoading}
-    />
-  );
+  return <HomeScreen />;
 }
 

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,15 +1,9 @@
 import React, { useContext } from "react";
-import CameraScreen from "@/components/CameraScreen";
+import ProgressScreen from "@/components/ProgressScreen";
 import { PhotoContext } from "./_layout";
 
 export default function ProgressPage() {
-  const { photos, setPhotos, loading, setLoading } = useContext(PhotoContext);
-  return (
-    <CameraScreen
-      photos={photos}
-      setPhotos={setPhotos}
-      loading={loading}
-      setLoading={setLoading}
-    />
-  );
+  const { photos, setPhotos } = useContext(PhotoContext);
+  return <ProgressScreen photos={photos} setPhotos={setPhotos} />;
 }
+

--- a/components/HomeScreen.js
+++ b/components/HomeScreen.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to FitnessGoals</Text>
+      <Text style={styles.subtitle}>
+        Track your progress and stay motivated!
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 10,
+  },
+  subtitle: {
+    fontSize: 16,
+    textAlign: "center",
+    color: "#666",
+  },
+});


### PR DESCRIPTION
## Summary
- Introduce a simple HomeScreen with welcome text
- Correct tab mappings so Home uses HomeScreen, Camera uses CameraScreen, and Progress uses ProgressScreen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689534aaa9e88323969605b1701feb56