### PR TITLE
Add onboarding auth flow with login and signup screens

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+
+export default function AuthLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="login" />
+      <Stack.Screen name="signup" />
+    </Stack>
+  );
+}

--- a/app/(auth)/index.tsx
+++ b/app/(auth)/index.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+
+const { width } = Dimensions.get('window');
+
+export default function IntroScreen() {
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  const slides = [
+    {
+      title: "Track Your Progress",
+      subtitle: "Take photos and let AI analyze your fitness journey",
+      icon: "📷",
+      colors: ['#A855F7', '#7C3AED']
+    },
+    {
+      title: "AI-Powered Analysis",
+      subtitle: "Get detailed insights about your body transformation",
+      icon: "⚡",
+      colors: ['#10B981', '#059669']
+    },
+    {
+      title: "Stay Motivated",
+      subtitle: "Build streaks and celebrate your achievements",
+      icon: "📈",
+      colors: ['#F59E0B', '#D97706']
+    }
+  ];
+
+  const nextSlide = () => {
+    if (currentSlide < slides.length - 1) {
+      setCurrentSlide(currentSlide + 1);
+    } else {
+      router.push('/(auth)/login');
+    }
+  };
+
+  const skipIntro = () => {
+    router.push('/(auth)/login');
+  };
+
+  const currentSlideData = slides[currentSlide];
+
+  return (
+    <LinearGradient colors={currentSlideData.colors} style={styles.container}>
+      <StatusBar style="light" />
+      
+      {/* Skip Button */}
+      <TouchableOpacity style={styles.skipButton} onPress={skipIntro}>
+        <Text style={styles.skipText}>Skip</Text>
+      </TouchableOpacity>
+
+      {/* Content */}
+      <View style={styles.content}>
+        <View style={styles.iconContainer}>
+          <Text style={styles.icon}>{currentSlideData.icon}</Text>
+        </View>
+        
+        <Text style={styles.title}>{currentSlideData.title}</Text>
+        <Text style={styles.subtitle}>{currentSlideData.subtitle}</Text>
+      </View>
+
+      {/* Navigation */}
+      <View style={styles.navigation}>
+        {/* Pagination */}
+        <View style={styles.pagination}>
+          {slides.map((_, index) => (
+            <View
+              key={index}
+              style={[
+                styles.paginationDot,
+                index === currentSlide && styles.paginationDotActive
+              ]}
+            />
+          ))}
+        </View>
+
+        {/* Next Button */}
+        <TouchableOpacity style={styles.nextButton} onPress={nextSlide}>
+          <Text style={styles.nextButtonText}>
+            {currentSlide === slides.length - 1 ? 'Get Started' : 'Next →'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  skipButton: {
+    alignSelf: 'flex-end',
+    padding: 20,
+    marginTop: 40,
+  },
+  skipText: {
+    color: 'white',
+    fontSize: 16,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 40,
+  },
+  iconContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 40,
+  },
+  icon: {
+    fontSize: 60,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: 'white',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: 'rgba(255,255,255,0.9)',
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  navigation: {
+    paddingHorizontal: 40,
+    paddingBottom: 60,
+    alignItems: 'center',
+  },
+  pagination: {
+    flexDirection: 'row',
+    marginBottom: 30,
+  },
+  paginationDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: 'rgba(255,255,255,0.4)',
+    marginHorizontal: 4,
+  },
+  paginationDotActive: {
+    width: 24,
+    backgroundColor: 'white',
+  },
+  nextButton: {
+    width: width - 80,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+    paddingVertical: 16,
+    borderRadius: 25,
+    alignItems: 'center',
+  },
+  nextButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+
+export default function LoginScreen() {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
+  const [errors, setErrors] = useState<{[key: string]: string}>({});
+
+  const validateForm = () => {
+    const newErrors: {[key: string]: string} = {};
+    
+    if (!formData.email.trim() || !formData.email.includes('@')) {
+      newErrors.email = 'Valid email is required';
+    }
+    
+    if (!formData.password.trim() || formData.password.length < 6) {
+      newErrors.password = 'Password must be at least 6 characters';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleLogin = async () => {
+    if (!validateForm()) return;
+    
+    setLoading(true);
+    
+    // Simulate API call
+    setTimeout(() => {
+      setLoading(false);
+      // Navigate to your existing home screen
+      router.replace('/(tabs)/homepage');
+    }, 2000);
+  };
+
+  const updateField = (field: string, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors(prev => ({ ...prev, [field]: '' }));
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar style="dark" />
+
+      {/* Header */}
+      <View style={styles.header}>
+        <View style={styles.logoContainer}>
+          <LinearGradient colors={['#A855F7', '#7C3AED']} style={styles.logo}>
+            <Text style={styles.logoEmoji}>💪</Text>
+          </LinearGradient>
+        </View>
+        
+        <Text style={styles.title}>CaptureFit</Text>
+        <Text style={styles.subtitle}>Welcome back!</Text>
+      </View>
+
+      {/* Form */}
+      <View style={styles.form}>
+        <View>
+          <View style={[styles.inputContainer, errors.email && styles.inputError]}>
+            <Ionicons name="mail-outline" size={20} color="#9CA3AF" />
+            <TextInput
+              style={styles.input}
+              placeholder="Email"
+              value={formData.email}
+              onChangeText={(text) => updateField('email', text)}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+          </View>
+          {errors.email && <Text style={styles.errorText}>{errors.email}</Text>}
+        </View>
+
+        <View>
+          <View style={[styles.inputContainer, errors.password && styles.inputError]}>
+            <Ionicons name="lock-closed-outline" size={20} color="#9CA3AF" />
+            <TextInput
+              style={styles.input}
+              placeholder="Password"
+              value={formData.password}
+              onChangeText={(text) => updateField('password', text)}
+              secureTextEntry
+            />
+          </View>
+          {errors.password && <Text style={styles.errorText}>{errors.password}</Text>}
+        </View>
+
+        <TouchableOpacity 
+          style={[styles.authButton, loading && styles.authButtonDisabled]} 
+          onPress={handleLogin}
+          disabled={loading}
+        >
+          <LinearGradient colors={['#A855F7', '#7C3AED']} style={styles.authButtonGradient}>
+            {loading ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text style={styles.authButtonText}>Sign In</Text>
+            )}
+          </LinearGradient>
+        </TouchableOpacity>
+
+        <TouchableOpacity 
+          style={styles.switchContainer}
+          onPress={() => router.push('/(auth)/signup')}
+        >
+          <Text style={styles.switchText}>{`Don't have an account?`}</Text>
+          <Text style={styles.switchLink}> Sign Up</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Text style={styles.footerText}>
+        By continuing, you agree to our Terms of Service
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  header: {
+    alignItems: 'center',
+    paddingVertical: 60,
+    paddingHorizontal: 32,
+  },
+  logoContainer: {
+    marginBottom: 20,
+  },
+  logo: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  logoEmoji: {
+    fontSize: 40,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#1F2937',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  form: {
+    flex: 1,
+    paddingHorizontal: 32,
+    gap: 16,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 12,
+  },
+  inputError: {
+    borderColor: '#EF4444',
+  },
+  input: {
+    flex: 1,
+    fontSize: 16,
+    color: '#1F2937',
+  },
+  errorText: {
+    color: '#EF4444',
+    fontSize: 12,
+    marginTop: 4,
+    marginLeft: 16,
+  },
+  authButton: {
+    marginTop: 24,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  authButtonDisabled: {
+    opacity: 0.5,
+  },
+  authButtonGradient: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  authButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  switchContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 24,
+  },
+  switchText: {
+    color: '#6B7280',
+    fontSize: 14,
+  },
+  switchLink: {
+    color: '#A855F7',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  footerText: {
+    textAlign: 'center',
+    color: '#9CA3AF',
+    fontSize: 12,
+    paddingHorizontal: 32,
+    paddingBottom: 32,
+  },
+});

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,0 +1,248 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+
+export default function SignupScreen() {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    fullName: '',
+    email: '',
+    password: '',
+  });
+  const [errors, setErrors] = useState<{[key: string]: string}>({});
+
+  const validateForm = () => {
+    const newErrors: {[key: string]: string} = {};
+    
+    if (!formData.fullName.trim()) {
+      newErrors.fullName = 'Full name is required';
+    }
+    
+    if (!formData.email.trim() || !formData.email.includes('@')) {
+      newErrors.email = 'Valid email is required';
+    }
+    
+    if (!formData.password.trim() || formData.password.length < 6) {
+      newErrors.password = 'Password must be at least 6 characters';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSignup = async () => {
+    if (!validateForm()) return;
+    
+    setLoading(true);
+    
+    // Simulate API call
+    setTimeout(() => {
+      setLoading(false);
+      // Navigate to your existing home screen
+      router.replace('/(tabs)/homepage');
+    }, 2000);
+  };
+
+  const updateField = (field: string, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors(prev => ({ ...prev, [field]: '' }));
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar style="dark" />
+
+      {/* Header */}
+      <View style={styles.header}>
+        <View style={styles.logoContainer}>
+          <LinearGradient colors={['#A855F7', '#7C3AED']} style={styles.logo}>
+            <Text style={styles.logoEmoji}>💪</Text>
+          </LinearGradient>
+        </View>
+        
+        <Text style={styles.title}>CaptureFit</Text>
+        <Text style={styles.subtitle}>Create your account</Text>
+      </View>
+
+      {/* Form */}
+      <View style={styles.form}>
+        <View>
+          <View style={[styles.inputContainer, errors.fullName && styles.inputError]}>
+            <Ionicons name="person-outline" size={20} color="#9CA3AF" />
+            <TextInput
+              style={styles.input}
+              placeholder="Full Name"
+              value={formData.fullName}
+              onChangeText={(text) => updateField('fullName', text)}
+              autoCapitalize="words"
+            />
+          </View>
+          {errors.fullName && <Text style={styles.errorText}>{errors.fullName}</Text>}
+        </View>
+
+        <View>
+          <View style={[styles.inputContainer, errors.email && styles.inputError]}>
+            <Ionicons name="mail-outline" size={20} color="#9CA3AF" />
+            <TextInput
+              style={styles.input}
+              placeholder="Email"
+              value={formData.email}
+              onChangeText={(text) => updateField('email', text)}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+          </View>
+          {errors.email && <Text style={styles.errorText}>{errors.email}</Text>}
+        </View>
+
+        <View>
+          <View style={[styles.inputContainer, errors.password && styles.inputError]}>
+            <Ionicons name="lock-closed-outline" size={20} color="#9CA3AF" />
+            <TextInput
+              style={styles.input}
+              placeholder="Password"
+              value={formData.password}
+              onChangeText={(text) => updateField('password', text)}
+              secureTextEntry
+            />
+          </View>
+          {errors.password && <Text style={styles.errorText}>{errors.password}</Text>}
+        </View>
+
+        <TouchableOpacity 
+          style={[styles.authButton, loading && styles.authButtonDisabled]} 
+          onPress={handleSignup}
+          disabled={loading}
+        >
+          <LinearGradient colors={['#A855F7', '#7C3AED']} style={styles.authButtonGradient}>
+            {loading ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text style={styles.authButtonText}>Create Account</Text>
+            )}
+          </LinearGradient>
+        </TouchableOpacity>
+
+        <TouchableOpacity 
+          style={styles.switchContainer}
+          onPress={() => router.push('/(auth)/login')}
+        >
+          <Text style={styles.switchText}>Already have an account?</Text>
+          <Text style={styles.switchLink}> Sign In</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Text style={styles.footerText}>
+        By continuing, you agree to our Terms of Service
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  header: {
+    alignItems: 'center',
+    paddingVertical: 60,
+    paddingHorizontal: 32,
+  },
+  logoContainer: {
+    marginBottom: 20,
+  },
+  logo: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  logoEmoji: {
+    fontSize: 40,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#1F2937',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  form: {
+    flex: 1,
+    paddingHorizontal: 32,
+    gap: 16,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 12,
+  },
+  inputError: {
+    borderColor: '#EF4444',
+  },
+  input: {
+    flex: 1,
+    fontSize: 16,
+    color: '#1F2937',
+  },
+  errorText: {
+    color: '#EF4444',
+    fontSize: 12,
+    marginTop: 4,
+    marginLeft: 16,
+  },
+  authButton: {
+    marginTop: 24,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  authButtonDisabled: {
+    opacity: 0.5,
+  },
+  authButtonGradient: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  authButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  switchContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 24,
+  },
+  switchText: {
+    color: '#6B7280',
+    fontSize: 14,
+  },
+  switchLink: {
+    color: '#A855F7',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  footerText: {
+    textAlign: 'center',
+    color: '#9CA3AF',
+    fontSize: 12,
+    paddingHorizontal: 32,
+    paddingBottom: 32,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,8 +19,9 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack initialRouteName="(tabs)">
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      <Stack screenOptions={{ headerShown: false }} initialRouteName="(auth)">
+        <Stack.Screen name="(auth)" />
+        <Stack.Screen name="(tabs)" />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />


### PR DESCRIPTION
## Summary
- add auth stack with onboarding index, login, and signup screens
- update root layout to start in auth flow before tabs

## Testing
- `npx expo install expo-linear-gradient @expo/vector-icons expo-status-bar` (failed: fetch failed)
- `npm run lint`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689680f463e4832387bb4a855f4069c0