### PR TITLE
Add settings screen with theme and auth contexts

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,17 +1,17 @@
-import { AuthContext } from "@/app/_layout";
 import { theme } from "@/constants/theme";
 import { useRouter } from "expo-router";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function LoginScreen() {
-  const { signIn } = useContext(AuthContext);
+  const { login } = useAuth();
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
   const handleLogin = async () => {
-    await signIn("token");
+    await login(email, password);
     router.replace("/(tabs)/homepage");
   };
 

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,18 +1,18 @@
-import { AuthContext } from "@/app/_layout";
 import { theme } from "@/constants/theme";
 import { useRouter } from "expo-router";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function SignupScreen() {
-  const { signIn } = useContext(AuthContext);
+  const { signup } = useAuth();
   const router = useRouter();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
   const handleSignup = async () => {
-    await signIn("token");
+    await signup(name, email, password);
     router.replace("/(tabs)/homepage");
   };
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useEffect } from "react";
 import { Tabs } from "expo-router";
-import { Feather, MaterialCommunityIcons } from "@expo/vector-icons";
+import { Feather, MaterialCommunityIcons, Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as FileSystem from "expo-file-system";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -110,7 +110,7 @@ export default function TabLayout() {
           options={{
             title: "Profile",
             tabBarIcon: ({ color, size }) => (
-              <Feather name="user" size={size} color={color} />
+              <Ionicons name="person" size={size} color={color} />
             ),
           }}
         />

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,6 +1,354 @@
-import React from 'react';
-import ProfileScreen from '@/components/ProfileScreen';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  Switch,
+  Alert
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import { StatusBar } from 'expo-status-bar';
+import { useTheme } from '../contexts/ThemeContext';
+import { useAuth } from '../contexts/AuthContext';
 
-export default function ProfilePage() {
-  return <ProfileScreen />;
+export default function ProfileScreen() {
+  const { theme, setTheme, isDarkMode, colors } = useTheme();
+  const { user, logout } = useAuth();
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+
+  const handleLogout = () => {
+    Alert.alert(
+      'Logout',
+      'Are you sure you want to logout?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Logout',
+          style: 'destructive',
+          onPress: logout
+        }
+      ]
+    );
+  };
+
+  const themeOptions = [
+    { value: 'light', label: 'Light', icon: 'sunny-outline' },
+    { value: 'dark', label: 'Dark', icon: 'moon-outline' },
+    { value: 'system', label: 'System', icon: 'phone-portrait-outline' },
+  ];
+
+  const SettingsSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
+      <Text style={[styles.sectionTitle, { color: colors.text }]}>{title}</Text>
+      {children}
+    </View>
+  );
+
+  const SettingsItem = ({ 
+    icon, 
+    title, 
+    subtitle, 
+    onPress, 
+    rightElement 
+  }: {
+    icon: string;
+    title: string;
+    subtitle?: string;
+    onPress?: () => void;
+    rightElement?: React.ReactNode;
+  }) => (
+    <TouchableOpacity 
+      style={[styles.settingsItem, { borderBottomColor: colors.border }]}
+      onPress={onPress}
+      disabled={!onPress}
+    >
+      <View style={styles.settingsItemLeft}>
+        <View style={[styles.iconContainer, { backgroundColor: colors.surface }]}>
+          <Ionicons name={icon as any} size={20} color={colors.primary} />
+        </View>
+        <View>
+          <Text style={[styles.settingsItemTitle, { color: colors.text }]}>{title}</Text>
+          {subtitle && (
+            <Text style={[styles.settingsItemSubtitle, { color: colors.textSecondary }]}>
+              {subtitle}
+            </Text>
+          )}
+        </View>
+      </View>
+      {rightElement || (
+        onPress && <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+      )}
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <StatusBar style={isDarkMode ? 'light' : 'dark'} />
+      <LinearGradient colors={[colors.primary, colors.primaryDark]} style={styles.header}>
+        <View style={styles.headerContent}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarText}>
+              {user?.fullName?.charAt(0) || 'U'}
+            </Text>
+          </View>
+          <View style={styles.userInfo}>
+            <Text style={styles.userName}>{user?.fullName || 'User'}</Text>
+            <Text style={styles.userEmail}>{user?.email || 'user@example.com'}</Text>
+          </View>
+        </View>
+      </LinearGradient>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <SettingsSection title="Account">
+          <SettingsItem
+            icon="person-outline"
+            title="Edit Profile"
+            subtitle="Update your personal information"
+            onPress={() => {}}
+          />
+          <SettingsItem
+            icon="lock-closed-outline"
+            title="Change Password"
+            subtitle="Update your password"
+            onPress={() => {}}
+          />
+          <SettingsItem
+            icon="shield-checkmark-outline"
+            title="Privacy & Security"
+            subtitle="Manage your privacy settings"
+            onPress={() => {}}
+          />
+        </SettingsSection>
+
+        <SettingsSection title="Camera & Photos">
+          <SettingsItem
+            icon="images-outline"
+            title="Auto Save to Gallery"
+            subtitle="Save progress photos automatically"
+            rightElement={
+              <Switch
+                value={true}
+                onValueChange={() => {}}
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={'#FFFFFF'}
+              />
+            }
+          />
+        </SettingsSection>
+
+        <SettingsSection title="App Settings">
+          <SettingsItem
+            icon="notifications-outline"
+            title="Notifications"
+            subtitle={notificationsEnabled ? 'Enabled' : 'Disabled'}
+            rightElement={
+              <Switch
+                value={notificationsEnabled}
+                onValueChange={setNotificationsEnabled}
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={notificationsEnabled ? '#FFFFFF' : colors.textTertiary}
+              />
+            }
+          />
+          <View style={styles.themeSection}>
+            <Text style={[styles.themeTitle, { color: colors.text }]}>Theme</Text>
+            <View style={styles.themeOptions}>
+              {themeOptions.map((option) => (
+                <TouchableOpacity
+                  key={option.value}
+                  style={[
+                    styles.themeOption,
+                    {
+                      backgroundColor: theme === option.value ? colors.primary : colors.surface,
+                      borderColor: colors.border
+                    },
+                  ]}
+                  onPress={() => setTheme(option.value as any)}
+                >
+                  <Ionicons
+                    name={option.icon as any}
+                    size={20}
+                    color={theme === option.value ? '#FFFFFF' : colors.text}
+                  />
+                  <Text
+                    style={[
+                      styles.themeOptionText,
+                      { color: theme === option.value ? '#FFFFFF' : colors.text },
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        </SettingsSection>
+
+        <SettingsSection title="Support">
+          <SettingsItem
+            icon="help-circle-outline"
+            title="Help & Support"
+            subtitle="Get help and contact support"
+            onPress={() => {}}
+          />
+          <SettingsItem
+            icon="document-text-outline"
+            title="Terms of Service"
+            onPress={() => {}}
+          />
+          <SettingsItem
+            icon="shield-outline"
+            title="Privacy Policy"
+            onPress={() => {}}
+          />
+          <SettingsItem
+            icon="information-circle-outline"
+            title="About"
+            subtitle="Version 1.0.0"
+            onPress={() => {}}
+          />
+        </SettingsSection>
+
+        <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+            <Ionicons name="log-out-outline" size={20} color={colors.error} />
+            <Text style={[styles.logoutText, { color: colors.error }]}>Logout</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.bottomSpacing} />
+      </ScrollView>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 60,
+    paddingBottom: 30,
+    paddingHorizontal: 24,
+  },
+  headerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatar: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  avatarText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  userInfo: {
+    flex: 1,
+  },
+  userName: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  userEmail: {
+    fontSize: 14,
+    color: 'rgba(255,255,255,0.8)',
+    marginTop: 2,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+  },
+  section: {
+    borderRadius: 12,
+    marginTop: 20,
+    borderWidth: 1,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    margin: 16,
+    marginBottom: 8,
+  },
+  settingsItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  settingsItemLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  iconContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  settingsItemTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  settingsItemSubtitle: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  themeSection: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  themeTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 12,
+  },
+  themeOptions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  themeOption: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    gap: 6,
+  },
+  themeOptionText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  logoutButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 16,
+    gap: 8,
+  },
+  logoutText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  bottomSpacing: {
+    height: 100,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,68 +1,20 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { DarkTheme, DefaultTheme, ThemeProvider } from "@react-navigation/native";
-import { useFonts } from "expo-font";
-import { Stack } from "expo-router";
-import { StatusBar } from "expo-status-bar";
-import React, {
-  createContext,
-  useEffect,
-  useState,
-} from "react";
-import "react-native-reanimated";
-
-import { useColorScheme } from "@/hooks/useColorScheme";
-
-export const AuthContext = createContext({
-  token: null as string | null,
-  signIn: async (_t: string) => {},
-  signOut: async () => {},
-});
+import { Stack } from 'expo-router';
+import React from 'react';
+import { ThemeProvider } from './contexts/ThemeContext';
+import { AuthProvider } from './contexts/AuthContext';
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
-  const [loaded] = useFonts({
-    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
-  });
-  const [token, setToken] = useState<string | null>(null);
-  const [checking, setChecking] = useState(true);
-
-  useEffect(() => {
-    AsyncStorage.getItem("userToken").then((t) => {
-      setToken(t);
-      setChecking(false);
-    });
-  }, []);
-
-  const authContext = {
-    token,
-    signIn: async (newToken: string) => {
-      await AsyncStorage.setItem("userToken", newToken);
-      setToken(newToken);
-    },
-    signOut: async () => {
-      await AsyncStorage.removeItem("userToken");
-      setToken(null);
-    },
-  };
-
-  if (!loaded || checking) {
-    // Async font loading only occurs in development.
-    return null;
-  }
-
   return (
-    <AuthContext.Provider value={authContext}>
-      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-        <Stack>
-          {token ? (
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          ) : (
-            <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-          )}
-          <Stack.Screen name="+not-found" />
+    <ThemeProvider>
+      <AuthProvider>
+        <Stack
+          screenOptions={{ headerShown: false }}
+          initialRouteName="(auth)"
+        >
+          <Stack.Screen name="(auth)" />
+          <Stack.Screen name="(tabs)" />
         </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </AuthContext.Provider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router } from 'expo-router';
+
+interface User {
+  id: string;
+  email: string;
+  fullName: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  isAuthenticated: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  signup: (fullName: string, email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    checkAuthStatus();
+  }, []);
+
+  const checkAuthStatus = async () => {
+    try {
+      const userData = await AsyncStorage.getItem('user');
+      if (userData) {
+        setUser(JSON.parse(userData));
+      }
+    } catch (error) {
+      console.log('Error checking auth status:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const login = async (email: string, password: string) => {
+    const realUser = {
+      id: Date.now().toString(),
+      email: email,
+      fullName: getNameFromEmail(email)
+    };
+    setUser(realUser);
+    await AsyncStorage.setItem('user', JSON.stringify(realUser));
+  };
+
+  const signup = async (fullName: string, email: string, password: string) => {
+    const realUser = {
+      id: Date.now().toString(),
+      email: email,
+      fullName: fullName
+    };
+    setUser(realUser);
+    await AsyncStorage.setItem('user', JSON.stringify(realUser));
+  };
+
+  const logout = async () => {
+    try {
+      setUser(null);
+      await AsyncStorage.removeItem('user');
+      router.replace('/(auth)');
+    } catch (error) {
+      console.log('Error logging out:', error);
+    }
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: !!user,
+        login,
+        signup,
+        logout,
+        loading,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+const getNameFromEmail = (email: string): string => {
+  const username = email.split('@')[0];
+  return username
+    .split(/[._-]/)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+};

--- a/app/contexts/ThemeContext.tsx
+++ b/app/contexts/ThemeContext.tsx
@@ -1,0 +1,90 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useColorScheme } from 'react-native';
+
+type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextType {
+  theme: Theme;
+  isDarkMode: boolean;
+  setTheme: (theme: Theme) => void;
+  colors: any;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};
+
+const lightColors = {
+  primary: '#A855F7',
+  primaryDark: '#7C3AED',
+  background: '#FFFFFF',
+  surface: '#F9FAFB',
+  card: '#FFFFFF',
+  text: '#1F2937',
+  textSecondary: '#6B7280',
+  textTertiary: '#9CA3AF',
+  border: '#E5E7EB',
+  error: '#EF4444',
+  success: '#10B981',
+  warning: '#F59E0B',
+};
+
+const darkColors = {
+  primary: '#A855F7',
+  primaryDark: '#7C3AED',
+  background: '#111827',
+  surface: '#1F2937',
+  card: '#374151',
+  text: '#F9FAFB',
+  textSecondary: '#D1D5DB',
+  textTertiary: '#9CA3AF',
+  border: '#4B5563',
+  error: '#EF4444',
+  success: '#10B981',
+  warning: '#F59E0B',
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>('system');
+  const systemColorScheme = useColorScheme();
+
+  const isDarkMode = theme === 'dark' || (theme === 'system' && systemColorScheme === 'dark');
+  const colors = isDarkMode ? darkColors : lightColors;
+
+  useEffect(() => {
+    loadTheme();
+  }, []);
+
+  const loadTheme = async () => {
+    try {
+      const savedTheme = await AsyncStorage.getItem('theme');
+      if (savedTheme) {
+        setThemeState(savedTheme as Theme);
+      }
+    } catch (error) {
+      console.log('Error loading theme:', error);
+    }
+  };
+
+  const setTheme = async (newTheme: Theme) => {
+    try {
+      setThemeState(newTheme);
+      await AsyncStorage.setItem('theme', newTheme);
+    } catch (error) {
+      console.log('Error saving theme:', error);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, isDarkMode, setTheme, colors }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- add theme context with persistent light/dark/system modes
- manage auth state and logout via new auth context
- introduce profile settings screen with theme selection and logout
- wire providers in root layout and update tab navigation and auth screens

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897924d41e08323bea5de8f8685b5d5