### PR TITLE
feat: add standalone settings screen

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, Switch, ScrollView, StyleSheet, Image, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router } from 'expo-router';
+
+interface User {
+  name: string;
+  email?: string;
+  avatar?: string;
+}
+
+const SettingsScreen = () => {
+  const [user, setUser] = useState<User | null>(null);
+  const [autoSave, setAutoSave] = useState(false);
+  const [notifications, setNotifications] = useState(false);
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    const loadUser = async () => {
+      const userData = await AsyncStorage.getItem('user');
+      if (userData) setUser(JSON.parse(userData));
+    };
+    loadUser();
+  }, []);
+
+  const handleLogout = () => {
+    Alert.alert('Logout', 'Are you sure?', [
+      { text: 'Cancel' },
+      {
+        text: 'Logout',
+        onPress: async () => {
+          await AsyncStorage.removeItem('user');
+          router.replace('/(auth)');
+        },
+      },
+    ]);
+  };
+
+  return (
+    <ScrollView style={styles.container} contentInsetAdjustmentBehavior="automatic">
+      <LinearGradient colors={['#A855F7', '#7C3AED']} style={styles.header}>
+        <View style={styles.headerTop}>
+          <TouchableOpacity onPress={() => router.back()}>
+            <Ionicons name="arrow-back" size={24} color="white" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Settings</Text>
+          <View style={styles.placeholder} />
+        </View>
+        {user && (
+          <View style={styles.userInfo}>
+            <Image
+              source={
+                user.avatar
+                  ? { uri: user.avatar }
+                  : require('../assets/images/icon.png')
+              }
+              style={styles.avatar}
+            />
+            <Text style={styles.userName}>{user.name}</Text>
+            {user.email && <Text style={styles.userEmail}>{user.email}</Text>}
+          </View>
+        )}
+      </LinearGradient>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Account</Text>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Edit Profile</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Change Password</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Privacy & Security</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Camera & Photos</Text>
+        <View style={styles.row}>
+          <Text style={styles.rowText}>Auto Save to Gallery</Text>
+          <Switch value={autoSave} onValueChange={setAutoSave} />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>App Settings</Text>
+        <View style={styles.row}>
+          <Text style={styles.rowText}>Notifications</Text>
+          <Switch value={notifications} onValueChange={setNotifications} />
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.rowText}>Dark Mode</Text>
+          <Switch value={darkMode} onValueChange={setDarkMode} />
+        </View>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Language</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Support</Text>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Help & Support</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Terms of Service</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>Privacy Policy</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.row}>
+          <Text style={styles.rowText}>About (Version 1.0.0)</Text>
+        </TouchableOpacity>
+      </View>
+
+      <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+        <Text style={styles.logoutText}>Logout</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  header: {
+    paddingTop: 50,
+    paddingBottom: 24,
+  },
+  headerTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+  },
+  headerTitle: {
+    color: 'white',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  placeholder: {
+    width: 24,
+  },
+  userInfo: {
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: 'rgba(255,255,255,0.3)',
+  },
+  userName: {
+    color: 'white',
+    fontSize: 20,
+    fontWeight: '600',
+    marginTop: 8,
+  },
+  userEmail: {
+    color: 'white',
+    opacity: 0.8,
+    marginTop: 4,
+  },
+  section: {
+    paddingHorizontal: 16,
+    paddingVertical: 24,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  rowText: {
+    color: '#374151',
+    fontSize: 16,
+  },
+  logoutButton: {
+    margin: 24,
+    paddingVertical: 12,
+    backgroundColor: '#EF4444',
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  logoutText: {
+    color: 'white',
+    fontWeight: '600',
+  },
+});
+
+export default SettingsScreen;

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { Feather } from '@expo/vector-icons';
+import { Feather, Ionicons } from '@expo/vector-icons';
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -14,6 +14,7 @@ import {
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import Layout from './Layout';
+import { router } from 'expo-router';
 
 const screenWidth = Dimensions.get('window').width;
 const PROFILE_CARD_MARGIN = 24;
@@ -207,8 +208,11 @@ const CaptureFitProfile = () => {
             <Feather name="arrow-left" size={20} color="#6B7280" />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>Profile</Text>
-          <TouchableOpacity style={styles.headerButton}>
-            <Feather name="settings" size={20} color="#6B7280" />
+          <TouchableOpacity
+            style={styles.headerButton}
+            onPress={() => router.push('/settings')}
+          >
+            <Ionicons name="settings" size={24} color="#666" />
           </TouchableOpacity>
         </View>
 


### PR DESCRIPTION
## Summary
- add standalone settings screen with back header and sections
- open settings by tapping the profile gear icon

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a830b1288323a1b2d72a74113d74