### PR TITLE
Add persistent settings screen and user data storage

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,6 +3,7 @@ import { theme } from "@/constants/theme";
 import { useRouter } from "expo-router";
 import React, { useContext, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export default function LoginScreen() {
   const { signIn } = useContext(AuthContext);
@@ -10,9 +11,27 @@ export default function LoginScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
+  const extractNameFromEmail = (email: string) => {
+    const username = email.split("@")[0];
+    return username
+      .split(/[._-]/)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+      .join(" ");
+  };
+
   const handleLogin = async () => {
-    await signIn("token");
-    router.replace("/(tabs)/homepage");
+    try {
+      const userData = {
+        fullName: extractNameFromEmail(email),
+        email,
+      };
+
+      await AsyncStorage.setItem("user", JSON.stringify(userData));
+      await signIn("token");
+      router.replace("/(tabs)/homepage");
+    } catch (error) {
+      console.log("Login error:", error);
+    }
   };
 
   return (

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -3,6 +3,7 @@ import { theme } from "@/constants/theme";
 import { useRouter } from "expo-router";
 import React, { useContext, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export default function SignupScreen() {
   const { signIn } = useContext(AuthContext);
@@ -12,8 +13,18 @@ export default function SignupScreen() {
   const [password, setPassword] = useState("");
 
   const handleSignup = async () => {
-    await signIn("token");
-    router.replace("/(tabs)/homepage");
+    try {
+      const userData = {
+        fullName: name,
+        email,
+      };
+
+      await AsyncStorage.setItem("user", JSON.stringify(userData));
+      await signIn("token");
+      router.replace("/(tabs)/homepage");
+    } catch (error) {
+      console.log("Signup error:", error);
+    }
   };
 
   return (

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, Switch, StyleSheet, TouchableOpacity } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { router } from "expo-router";
+
+export default function SettingsScreen() {
+  const [darkMode, setDarkMode] = useState(false);
+  const [notifications, setNotifications] = useState(false);
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const user = await AsyncStorage.getItem("user");
+        if (user) {
+          const parsed = JSON.parse(user);
+          setName(parsed.fullName);
+        }
+        const savedDark = await AsyncStorage.getItem("settings:darkMode");
+        const savedNotifications = await AsyncStorage.getItem("settings:notifications");
+        if (savedDark !== null) setDarkMode(savedDark === "true");
+        if (savedNotifications !== null) setNotifications(savedNotifications === "true");
+      } catch (e) {
+        console.log("Load settings error", e);
+      }
+    };
+    loadSettings();
+  }, []);
+
+  const toggleDarkMode = async () => {
+    const next = !darkMode;
+    setDarkMode(next);
+    await AsyncStorage.setItem("settings:darkMode", JSON.stringify(next));
+  };
+
+  const toggleNotifications = async () => {
+    const next = !notifications;
+    setNotifications(next);
+    await AsyncStorage.setItem("settings:notifications", JSON.stringify(next));
+  };
+
+  const handleLogout = async () => {
+    await AsyncStorage.clear();
+    router.replace("/(auth)/login");
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Settings</Text>
+      {name ? <Text style={styles.subtitle}>{name}</Text> : null}
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Dark Mode</Text>
+        <Switch value={darkMode} onValueChange={toggleDarkMode} />
+      </View>
+
+      <View style={styles.row}>
+        <Text style={styles.label}>Notifications</Text>
+        <Switch value={notifications} onValueChange={toggleNotifications} />
+      </View>
+
+      <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+        <Text style={styles.logoutText}>Log Out</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    backgroundColor: "#fff",
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  subtitle: {
+    fontSize: 16,
+    color: "#6B7280",
+    marginBottom: 32,
+    textAlign: "center",
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+  label: {
+    fontSize: 16,
+    color: "#374151",
+  },
+  logoutButton: {
+    marginTop: 32,
+    backgroundColor: "#EF4444",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  logoutText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+});
+

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { Feather } from '@expo/vector-icons';
+import { Feather, Ionicons } from '@expo/vector-icons';
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -11,6 +11,7 @@ import {
     Modal,
     TextInput,
 } from 'react-native';
+import { router } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import Layout from './Layout';
@@ -207,8 +208,11 @@ const CaptureFitProfile = () => {
             <Feather name="arrow-left" size={20} color="#6B7280" />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>Profile</Text>
-          <TouchableOpacity style={styles.headerButton}>
-            <Feather name="settings" size={20} color="#6B7280" />
+          <TouchableOpacity
+            style={styles.headerButton}
+            onPress={() => router.push('/settings')}
+          >
+            <Ionicons name="settings" size={24} color="#666" />
           </TouchableOpacity>
         </View>
 


### PR DESCRIPTION
## Summary
- add new settings screen with dark mode, notifications, and logout
- store real user data on login and signup
- make profile gear icon open settings

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npx expo install @react-native-async-storage/async-storage` (fails: TypeError: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_6897af4474288323be0ceb7c35f3ec55