### PR TITLE
Fix logout route in settings screen

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { theme } from '@/constants/theme';
+
+export default function SettingsScreen() {
+  const router = useRouter();
+
+  const handleLogout = () => {
+    // Navigate to the login screen after logout
+    router.replace('/login');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Pressable style={styles.button} onPress={handleLogout}>
+        <Text style={styles.buttonText}>Log Out</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'white',
+  },
+  button: {
+    backgroundColor: theme.colors.primary,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 12,
+  },
+  buttonText: {
+    color: 'white',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+});
+


### PR DESCRIPTION
## Summary
- Ensure Settings screen redirects to `/login` after logout so Expo Router resolves correctly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897b1f6a334832393ae8d996f9ee062