### PR TITLE
Add settings screen with persistent user preferences

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,16 +3,46 @@ import { theme } from "@/constants/theme";
 import { useRouter } from "expo-router";
 import React, { useContext, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default function LoginScreen() {
   const { signIn } = useContext(AuthContext);
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [, setLoading] = useState(false);
+
+  const extractNameFromEmail = (email: string) => {
+    const username = email.split('@')[0];
+    return username
+      .split(/[._-]/)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+      .join(' ');
+  };
 
   const handleLogin = async () => {
-    await signIn("token");
-    router.replace("/(tabs)/homepage");
+    if (!email || !password) return;
+
+    setLoading(true);
+
+    try {
+      // Save user data (extract name from email)
+      const userData = {
+        fullName: extractNameFromEmail(email),
+        email: email,
+      };
+
+      console.log('💾 Saving user data:', userData);
+      await AsyncStorage.setItem('user', JSON.stringify(userData));
+      console.log('✅ User data saved successfully');
+
+      await signIn("token");
+      router.replace("/(tabs)/homepage");
+    } catch (error) {
+      console.log('❌ Login error:', error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -3,6 +3,7 @@ import { theme } from "@/constants/theme";
 import { useRouter } from "expo-router";
 import React, { useContext, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default function SignupScreen() {
   const { signIn } = useContext(AuthContext);
@@ -10,10 +11,31 @@ export default function SignupScreen() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [, setLoading] = useState(false);
 
   const handleSignup = async () => {
-    await signIn("token");
-    router.replace("/(tabs)/homepage");
+    if (!name || !email || !password) return;
+
+    setLoading(true);
+
+    try {
+      // Save REAL user data from signup form
+      const userData = {
+        fullName: name,
+        email: email,
+      };
+
+      console.log('💾 Saving user data:', userData);
+      await AsyncStorage.setItem('user', JSON.stringify(userData));
+      console.log('✅ User data saved successfully');
+
+      await signIn("token");
+      router.replace("/(tabs)/homepage");
+    } catch (error) {
+      console.log('❌ Signup error:', error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -14,6 +14,8 @@ import { StatusBar } from 'expo-status-bar';
 import { router } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+export const options = { headerShown: false };
+
 export default function SettingsScreen() {
   const [user, setUser] = useState({ fullName: 'User', email: 'user@example.com' });
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -236,8 +238,7 @@ export default function SettingsScreen() {
         <View>
           <Text style={[styles.settingsItemTitle, { color: colors.text }]}>{title}</Text>
           {subtitle && (
-            <Text style={[styles.settingsItemSubtitle, { color: colors.textSecondary }]}>\n              {subtitle}
-            </Text>
+            <Text style={[styles.settingsItemSubtitle, { color: colors.textSecondary }]}>{subtitle}</Text>
           )}
         </View>
       </View>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,542 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  View, 
+  Text, 
+  TouchableOpacity, 
+  StyleSheet, 
+  ScrollView, 
+  Switch,
+  Alert 
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import { StatusBar } from 'expo-status-bar';
+import { router } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export default function SettingsScreen() {
+  const [user, setUser] = useState({ fullName: 'User', email: 'user@example.com' });
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const [autoSave, setAutoSave] = useState(true);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadAllSettings();
+  }, []);
+
+  const loadAllSettings = async () => {
+    try {
+      console.log('📱 Loading all settings...');
+      
+      // Load user data
+      const userData = await AsyncStorage.getItem('user');
+      console.log('👤 User data from storage:', userData);
+      if (userData) {
+        const parsedUser = JSON.parse(userData);
+        setUser(parsedUser);
+        console.log('👤 Set user to:', parsedUser);
+      }
+
+      // Load settings
+      const darkMode = await AsyncStorage.getItem('darkMode');
+      const notifications = await AsyncStorage.getItem('notifications');
+      const autoSaveGallery = await AsyncStorage.getItem('autoSave');
+      
+      console.log('🌙 Dark mode from storage:', darkMode);
+      console.log('🔔 Notifications from storage:', notifications);
+      console.log('📸 Auto save from storage:', autoSaveGallery);
+
+      if (darkMode !== null) {
+        const darkModeValue = JSON.parse(darkMode);
+        setIsDarkMode(darkModeValue);
+        console.log('🌙 Set dark mode to:', darkModeValue);
+      }
+      if (notifications !== null) {
+        const notificationsValue = JSON.parse(notifications);
+        setNotificationsEnabled(notificationsValue);
+        console.log('🔔 Set notifications to:', notificationsValue);
+      }
+      if (autoSaveGallery !== null) {
+        const autoSaveValue = JSON.parse(autoSaveGallery);
+        setAutoSave(autoSaveValue);
+        console.log('📸 Set auto save to:', autoSaveValue);
+      }
+
+      console.log('✅ All settings loaded successfully');
+    } catch (error) {
+      console.log('❌ Error loading settings:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveSetting = async (key, value) => {
+    try {
+      console.log(`💾 Saving ${key}:`, value);
+      await AsyncStorage.setItem(key, JSON.stringify(value));
+      console.log(`✅ Successfully saved ${key} to AsyncStorage`);
+      return true;
+    } catch (error) {
+      console.log(`❌ Error saving ${key}:`, error);
+      return false;
+    }
+  };
+
+  const handleDarkModeToggle = async (value) => {
+    console.log('🌙 Dark mode toggle called with value:', value);
+    
+    // Update state immediately
+    setIsDarkMode(value);
+    console.log('🌙 Dark mode state updated to:', value);
+    
+    // Save to storage
+    const saveSuccess = await saveSetting('darkMode', value);
+    
+    if (saveSuccess) {
+      Alert.alert(
+        'Theme Changed', 
+        `Switched to ${value ? 'dark' : 'light'} mode`,
+        [{ text: 'OK' }]
+      );
+    } else {
+      Alert.alert('Error', 'Failed to save dark mode setting');
+      // Revert state if save failed
+      setIsDarkMode(!value);
+    }
+  };
+
+  const handleNotificationsToggle = async (value) => {
+    console.log('🔔 Notifications toggle called with value:', value);
+    
+    // Update state immediately
+    setNotificationsEnabled(value);
+    console.log('🔔 Notifications state updated to:', value);
+    
+    // Save to storage
+    const saveSuccess = await saveSetting('notifications', value);
+    
+    if (saveSuccess) {
+      if (value) {
+        Alert.alert(
+          'Notifications Enabled', 
+          'You will receive workout reminders and progress updates',
+          [{ text: 'OK' }]
+        );
+      } else {
+        Alert.alert(
+          'Notifications Disabled', 
+          'You will no longer receive push notifications',
+          [{ text: 'OK' }]
+        );
+      }
+    } else {
+      Alert.alert('Error', 'Failed to save notification setting');
+      // Revert state if save failed
+      setNotificationsEnabled(!value);
+    }
+  };
+
+  const handleAutoSaveToggle = async (value) => {
+    console.log('📸 Auto save toggle called with value:', value);
+    
+    // Update state immediately
+    setAutoSave(value);
+    console.log('📸 Auto save state updated to:', value);
+    
+    // Save to storage
+    const saveSuccess = await saveSetting('autoSave', value);
+    
+    if (saveSuccess) {
+      Alert.alert(
+        'Auto Save Settings', 
+        value ? 'Progress photos will be saved to your gallery automatically' : 'Photos will only be saved in the app',
+        [{ text: 'OK' }]
+      );
+    } else {
+      Alert.alert('Error', 'Failed to save auto save setting');
+      // Revert state if save failed
+      setAutoSave(!value);
+    }
+  };
+
+  const handleLogout = () => {
+    Alert.alert(
+      'Logout',
+      'Are you sure you want to logout? This will clear all your data.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { 
+          text: 'Logout', 
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              console.log('🚪 Logging out...');
+              // Clear all user data and settings
+              await AsyncStorage.multiRemove(['user', 'darkMode', 'notifications', 'autoSave']);
+              console.log('🗑️ All data cleared from AsyncStorage');
+              router.replace('/(auth)');
+              console.log('🔄 Navigated to auth screen');
+            } catch (error) {
+              console.log('❌ Error logging out:', error);
+              Alert.alert('Error', 'Failed to logout. Please try again.');
+            }
+          }
+        }
+      ]
+    );
+  };
+
+  // Dynamic colors based on dark mode
+  const colors = isDarkMode ? {
+    primary: '#A855F7',
+    primaryDark: '#7C3AED',
+    background: '#111827',
+    surface: '#1F2937',
+    card: '#374151',
+    text: '#F9FAFB',
+    textSecondary: '#D1D5DB',
+    textTertiary: '#9CA3AF',
+    border: '#4B5563',
+    error: '#EF4444',
+  } : {
+    primary: '#A855F7',
+    primaryDark: '#7C3AED',
+    background: '#FFFFFF',
+    surface: '#F9FAFB',
+    card: '#FFFFFF',
+    text: '#1F2937',
+    textSecondary: '#6B7280',
+    textTertiary: '#9CA3AF',
+    border: '#E5E7EB',
+    error: '#EF4444',
+  };
+
+  const SettingsSection = ({ title, children }) => (
+    <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
+      <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>{title}</Text>
+      {children}
+    </View>
+  );
+
+  const SettingsItem = ({ icon, title, subtitle, onPress, rightElement, isLast = false }) => (
+    <TouchableOpacity 
+      style={[
+        styles.settingsItem, 
+        { borderBottomColor: colors.border },
+        isLast && { borderBottomWidth: 0 }
+      ]}
+      onPress={onPress}
+      disabled={!onPress}
+    >
+      <View style={styles.settingsItemLeft}>
+        <View style={[styles.iconContainer, { backgroundColor: colors.surface }]}>
+          <Ionicons name={icon} size={20} color={colors.primary} />
+        </View>
+        <View>
+          <Text style={[styles.settingsItemTitle, { color: colors.text }]}>{title}</Text>
+          {subtitle && (
+            <Text style={[styles.settingsItemSubtitle, { color: colors.textSecondary }]}>\n              {subtitle}
+            </Text>
+          )}
+        </View>
+      </View>
+      {rightElement || (onPress && <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />)}
+    </TouchableOpacity>
+  );
+
+  if (loading) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' }]}>
+        <Text style={{ color: colors.text, fontSize: 16 }}>Loading settings...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <StatusBar style={isDarkMode ? 'light' : 'dark'} />
+      
+      {/* Header */}
+      <LinearGradient colors={[colors.primary, colors.primaryDark]} style={styles.header}>
+        <View style={styles.headerTop}>
+          <TouchableOpacity 
+            onPress={() => {
+              console.log('🔙 Back button pressed');
+              router.back();
+            }}
+            style={styles.backButton}
+          >
+            <Ionicons name="arrow-back" size={24} color="white" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Settings</Text>
+          <View style={styles.placeholder} />
+        </View>
+        
+        <View style={styles.headerContent}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarText}>
+              {user?.fullName?.charAt(0)?.toUpperCase() || 'U'}
+            </Text>
+          </View>
+          <View style={styles.userInfo}>
+            <Text style={styles.userName}>{user?.fullName || 'User'}</Text>
+            <Text style={styles.userEmail}>{user?.email || 'user@example.com'}</Text>
+          </View>
+        </View>
+      </LinearGradient>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        {/* Account Settings */}
+        <SettingsSection title="Account">
+          <SettingsItem
+            icon="person-outline"
+            title="Edit Profile"
+            subtitle="Update your personal information"
+            onPress={() => Alert.alert('Edit Profile', 'Profile editing coming soon!')}
+          />
+          <SettingsItem
+            icon="lock-closed-outline"
+            title="Change Password"
+            subtitle="Update your password"
+            onPress={() => Alert.alert('Change Password', 'Password change coming soon!')}
+          />
+          <SettingsItem
+            icon="shield-checkmark-outline"
+            title="Privacy & Security"
+            subtitle="Manage your privacy settings"
+            onPress={() => Alert.alert('Privacy & Security', 'Privacy settings coming soon!')}
+            isLast
+          />
+        </SettingsSection>
+
+        {/* Camera & Photos */}
+        <SettingsSection title="Camera & Photos">
+          <SettingsItem
+            icon="images-outline"
+            title="Auto Save to Gallery"
+            subtitle={autoSave ? "Photos saved to gallery" : "Photos saved in app only"}
+            rightElement={
+              <Switch
+                value={autoSave}
+                onValueChange={(value) => {
+                  console.log('📸 Auto save switch toggled to:', value);
+                  handleAutoSaveToggle(value);
+                }}
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={'#FFFFFF'}
+              />
+            }
+            isLast
+          />
+        </SettingsSection>
+
+        {/* App Settings */}
+        <SettingsSection title="App Settings">
+          <SettingsItem
+            icon="notifications-outline"
+            title="Notifications"
+            subtitle={notificationsEnabled ? 'Workout reminders enabled' : 'All notifications disabled'}
+            rightElement={
+              <Switch
+                value={notificationsEnabled}
+                onValueChange={(value) => {
+                  console.log('🔔 Notifications switch toggled to:', value);
+                  handleNotificationsToggle(value);
+                }}
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={'#FFFFFF'}
+              />
+            }
+          />
+          <SettingsItem
+            icon={isDarkMode ? "moon" : "sunny"}
+            title="Appearance"
+            subtitle={isDarkMode ? 'Dark mode active' : 'Light mode active'}
+            rightElement={
+              <Switch
+                value={isDarkMode}
+                onValueChange={(value) => {
+                  console.log('🌙 Dark mode switch toggled to:', value);
+                  handleDarkModeToggle(value);
+                }}
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={'#FFFFFF'}
+              />
+            }
+          />
+          <SettingsItem
+            icon="language-outline"
+            title="Language"
+            subtitle="English"
+            onPress={() => Alert.alert('Language', 'Language settings coming soon!')}
+            isLast
+          />
+        </SettingsSection>
+
+        {/* Support */}
+        <SettingsSection title="Support">
+          <SettingsItem
+            icon="help-circle-outline"
+            title="Help & Support"
+            subtitle="Get help and contact support"
+            onPress={() => Alert.alert('Help & Support', 'Support coming soon!')}
+          />
+          <SettingsItem
+            icon="document-text-outline"
+            title="Terms of Service"
+            onPress={() => Alert.alert('Terms of Service', 'Terms coming soon!')}
+          />
+          <SettingsItem
+            icon="shield-outline"
+            title="Privacy Policy"
+            onPress={() => Alert.alert('Privacy Policy', 'Privacy policy coming soon!')}
+          />
+          <SettingsItem
+            icon="information-circle-outline"
+            title="About"
+            subtitle="Version 1.0.0"
+            onPress={() => Alert.alert('About CaptureFit', 'AI-powered fitness progress tracking app')}
+            isLast
+          />
+        </SettingsSection>
+
+        {/* Logout */}
+        <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }] }>
+          <TouchableOpacity 
+            style={styles.logoutButton}
+            onPress={() => {
+              console.log('🚪 Logout button pressed');
+              handleLogout();
+            }}
+          >
+            <Ionicons name="log-out-outline" size={20} color={colors.error} />
+            <Text style={[styles.logoutText, { color: colors.error }]}>Logout</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.bottomSpacing} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 60,
+    paddingBottom: 30,
+    paddingHorizontal: 24,
+  },
+  headerTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 20,
+  },
+  backButton: {
+    padding: 4,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  placeholder: {
+    width: 32,
+  },
+  headerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatar: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  avatarText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  userInfo: {
+    flex: 1,
+  },
+  userName: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  userEmail: {
+    fontSize: 14,
+    color: 'rgba(255,255,255,0.8)',
+    marginTop: 2,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+  },
+  section: {
+    borderRadius: 12,
+    marginTop: 20,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    margin: 16,
+    marginBottom: 8,
+    textTransform: 'uppercase',
+  },
+  settingsItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    minHeight: 60,
+  },
+  settingsItemLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  iconContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  settingsItemTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  settingsItemSubtitle: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  logoutButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 16,
+    gap: 8,
+  },
+  logoutText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  bottomSpacing: {
+    height: 100,
+  },
+});

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { Feather } from '@expo/vector-icons';
+import { Feather, Ionicons } from '@expo/vector-icons';
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -14,6 +14,7 @@ import {
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import Layout from './Layout';
+import { router } from 'expo-router';
 
 const screenWidth = Dimensions.get('window').width;
 const PROFILE_CARD_MARGIN = 24;
@@ -207,8 +208,14 @@ const CaptureFitProfile = () => {
             <Feather name="arrow-left" size={20} color="#6B7280" />
           </TouchableOpacity>
           <Text style={styles.headerTitle}>Profile</Text>
-          <TouchableOpacity style={styles.headerButton}>
-            <Feather name="settings" size={20} color="#6B7280" />
+          <TouchableOpacity 
+            style={styles.headerButton}
+            onPress={() => {
+              console.log('⚙️ Gear icon pressed - navigating to settings');
+              router.push('/settings');
+            }}
+          >
+            <Ionicons name="settings" size={24} color="#666" />
           </TouchableOpacity>
         </View>
 


### PR DESCRIPTION
## Summary
- create comprehensive settings screen with dark mode, notifications, auto save toggles and logout
- persist user profile info and settings using AsyncStorage
- make profile gear navigate to settings

## Testing
- `npx expo install @react-native-async-storage/async-storage` *(failed: fetch failed)*
- `npm test` *(missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897b468960c8323a20a67ad96b9170a