### PR TITLE
Respect dark mode setting across app

### DIFF
--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,21 @@
-export { useColorScheme } from 'react-native';
+import { useContext } from 'react';
+import { ThemeContext } from '@/app/_layout';
+import { useColorScheme as useRNColorScheme } from 'react-native';
+
+// Custom hook that returns the current color scheme for the app.
+// It first tries to read the value from our ThemeContext (which is
+// controlled by the user via the settings screen). If the context is
+// not available, we fall back to the system color scheme provided by
+// React Native. This ensures that toggling dark mode in settings
+// affects the entire application.
+export function useColorScheme() {
+  const themeContext = useContext(ThemeContext);
+  const systemScheme = useRNColorScheme();
+
+  if (themeContext) {
+    return themeContext.isDarkMode ? 'dark' : 'light';
+  }
+
+  return systemScheme;
+}
+

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,15 +1,22 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { ThemeContext } from '@/app/_layout';
 import { useColorScheme as useRNColorScheme } from 'react-native';
 
 /**
  * To support static rendering, this value needs to be re-calculated on the client side for web
  */
 export function useColorScheme() {
+  const themeContext = useContext(ThemeContext);
   const [hasHydrated, setHasHydrated] = useState(false);
 
   useEffect(() => {
     setHasHydrated(true);
   }, []);
+
+  // If ThemeContext is available, prefer it so user-selected theme is used.
+  if (themeContext) {
+    return themeContext.isDarkMode ? 'dark' : 'light';
+  }
 
   const colorScheme = useRNColorScheme();
 


### PR DESCRIPTION
## Summary
- Read theme selection from ThemeContext in `useColorScheme` hooks
- Fall back to system scheme when context not available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a78c5daf4832395fb98efa61901b5