### PR TITLE
feat: add global theme with persisted dark mode

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,10 +1,9 @@
-import { Colors } from "@/constants/Colors";
+import { ThemeContext } from "@/app/_layout";
 import { Feather, MaterialCommunityIcons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as FileSystem from "expo-file-system";
 import { Tabs } from "expo-router";
-import React, { createContext, useEffect, useState } from "react";
-import { useColorScheme } from "react-native";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export type RootStackParamList = {
@@ -41,7 +40,8 @@ export default function TabLayout() {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [loading, setLoading] = useState(false);
   const insets = useSafeAreaInsets();
-  const colorScheme = useColorScheme();
+  const themeContext = useContext(ThemeContext);
+  const theme = themeContext?.theme!;
 
   useEffect(() => {
     loadPhotos();
@@ -83,10 +83,10 @@ export default function TabLayout() {
         screenOptions={{
           headerShown: false,
           tabBarShowLabel: false,
-          tabBarActiveTintColor: Colors[colorScheme ?? "light"].tint,
-          tabBarInactiveTintColor: "#9AA1B9",
+          tabBarActiveTintColor: theme.primary,
+          tabBarInactiveTintColor: theme.textSecondary,
           tabBarStyle: {
-            backgroundColor: Colors[colorScheme ?? "light"].background,
+            backgroundColor: theme.background,
             borderTopWidth: 0,
             elevation: 5,
             height: 60 + insets.bottom,

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -12,6 +12,7 @@ export default function SettingsScreen() {
   const themeContext = useContext(ThemeContext);
   const isDarkMode = themeContext?.isDarkMode ?? false;
   const toggleDarkMode = themeContext?.toggleDarkMode ?? (() => {});
+  const theme = themeContext?.theme;
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [autoSave, setAutoSave] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -131,31 +132,7 @@ export default function SettingsScreen() {
     ]);
   };
 
-  const colors = isDarkMode
-    ? {
-        primary: '#A855F7',
-        primaryDark: '#7C3AED',
-        background: '#111827',
-        surface: '#1F2937',
-        card: '#374151',
-        text: '#F9FAFB',
-        textSecondary: '#D1D5DB',
-        textTertiary: '#9CA3AF',
-        border: '#4B5563',
-        error: '#EF4444',
-      }
-    : {
-        primary: '#A855F7',
-        primaryDark: '#7C3AED',
-        background: '#FFFFFF',
-        surface: '#F9FAFB',
-        card: '#FFFFFF',
-        text: '#1F2937',
-        textSecondary: '#6B7280',
-        textTertiary: '#9CA3AF',
-        border: '#E5E7EB',
-        error: '#EF4444',
-      };
+  const colors = theme!;
 
   const SettingsSection = ({ title, children }: { title: string, children: React.ReactNode }) => (
     <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>


### PR DESCRIPTION
## Summary
- add ThemeContext providing light/dark palettes and persisted dark-mode state
- apply theme colors to navigation headers, backgrounds, and status bar
- use context-driven theme and toggle in settings screen and tab navigator

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7cce80c8832382e467d29bacf9c4